### PR TITLE
Auto deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy Client Application
+
+on:
+  workflow_dispatch: # run when somebody pushes the button
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: Cache npm local files
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.npm
+          ./frontend/node_modules
+        key: npm-build-${{ hashFiles('client/package-lock.json', 'client/package.json') }}
+    - name: Node setup
+      working-directory: ./frontend
+      run: npm install
+    - name: Application build
+      working-directory: ./frontend
+      run: npm build
+    - name: Deploy
+      uses: usds/cloud-gov-cli@master
+      with:
+        org: sandbox-dhs
+        user: ${{secrets.SERVICE_USER}}
+        password: ${{secrets.SERVICE_AUTH}}
+        manifest: frontend/manifest.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Deploy
       uses: usds/cloud-gov-cli@master
       with:
-        org: sandbox-dhs
+        org: ${{secrets.CLOUD_GOV_ORG}}
         user: ${{secrets.SERVICE_USER}}
         password: ${{secrets.SERVICE_AUTH}}
         manifest: frontend/manifest.yml

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             ~/.npm
-            ./node_modules
+            ./frontend/node_modules
           key: npm-${{ hashFiles('frontend/package-lock.json', 'frontend/package.json') }}
       - name: Node setup
         run: npm install
@@ -55,7 +55,7 @@ jobs:
         with:
           path: |
             ~/.npm
-            ./node_modules
+            ./frontend/node_modules
           key: npm-${{ hashFiles('frontend/package-lock.json', 'frontend/package.json') }}
       - name: Node setup
         run: npm install

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -1,6 +1,6 @@
 # Smoketest/code lint checks for frontend package
 
-name: Smoketests
+name: Smoke Test Client
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch


### PR DESCRIPTION
Added a workflow that purports to deploy the client application to cloud.gov.

TODO:
- [x] fix the `org` argument to point to the right place
- [x] get the credentials created and stored in the right place (or update the workflow to point to the right place if they are there already)
- [ ] verify that we don't need to add a working-directory argument to usds/cloud-gov-cli, because cf7 handles relative paths, right??