### PR TITLE
Added a staging deployment to the autodeploy workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,18 @@ name: Deploy Client Application
 
 on:
   workflow_dispatch: # run when somebody pushes the button
+  push:
+    branches: # run when we merge to the "staging" branch
+      - staging
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      # VERY IMPORTANT: if you run this on any branch other than master, it will
+      # deploy to staging
+    - name: Choose deployment environment
+      run: echo >> $GITHUB_ENV deploy_env=$( [[ "$GITHUB_REF" == "/refs/heads/main" ]] && echo "client" || echo "staging")
     - name: Use Node.js 12
       uses: actions/setup-node@v1
       with:
@@ -30,4 +37,5 @@ jobs:
         org: ${{secrets.CLOUD_GOV_ORG}}
         user: ${{secrets.SERVICE_USER}}
         password: ${{secrets.SERVICE_PASSWORD}}
+        application: prime-data-input-${{env.DEPLOY_ENV}}
         manifest: frontend/manifest.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
 name: Deploy Client Application
 
+env:
+  DEMO_CF_APP: "prime-data-input-client" # the app name if we are deploying 'main'
+  STAGING_CF_APP: "prime-data-input-staging" # the app name if we are deploying any other branch
 on:
-  workflow_dispatch: # run when somebody pushes the button
+  workflow_dispatch: # run when somebody pushes the button (on whatever branch they choose)
   push:
-    branches: # run when we merge to the "staging" branch
+    branches: # automatically deploy the "staging" branch on every push
       - staging
 jobs:
   build-and-deploy:
@@ -11,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       # VERY IMPORTANT: if you run this on any branch other than master, it will
-      # deploy to staging
+      # deploy to STAGING_CF_APP
     - name: Choose deployment environment
-      run: echo >> $GITHUB_ENV deploy_env=$( [[ "$GITHUB_REF" == "/refs/heads/main" ]] && echo "client" || echo "staging")
+      run: echo >> $GITHUB_ENV CF_APPLICATION=$( [[ "$GITHUB_REF" == "/refs/heads/main" ]] && echo "$DEMO_CF_APP" || echo "$STAGING_CF_APP")
     - name: Use Node.js 12
       uses: actions/setup-node@v1
       with:
@@ -37,5 +40,5 @@ jobs:
         org: ${{secrets.CLOUD_GOV_ORG}}
         user: ${{secrets.SERVICE_USER}}
         password: ${{secrets.SERVICE_PASSWORD}}
-        application: prime-data-input-${{env.DEPLOY_ENV}}
+        application: $CF_APPLICATION
         manifest: frontend/manifest.yml

--- a/.github/workflows/restage.yml
+++ b/.github/workflows/restage.yml
@@ -1,0 +1,20 @@
+name: Restage Application
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy-to:
+        description: Which instance should we restage ("client" or "staging")?
+        default: staging
+jobs:
+  restage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Restage Application
+      uses: usds/cloud-gov-cli@master
+      with:
+        org: ${{secrets.CLOUD_GOV_ORG}}
+        user: ${{secrets.SERVICE_USER}}
+        password: ${{secrets.SERVICE_PASSWORD}}
+        application: prime-data-input-${{github.event.inputs.deploy-to}}
+        command: restage

--- a/README.md
+++ b/README.md
@@ -92,20 +92,34 @@ docker run \
 
 - establish a workflow where you can add depedencies (via `npm install <dependency>`) without having to manually stop the container, rebuild, and restart.
 
-## DEPLOY (staging env)
+## DEPLOY
 
-1. Build the appp
+## To deploy to the stable (ish) demo environment:
 
-   > cd frontend
-   > npm run build
+1. Point your browser to the [Deploy Client Application](actions?query=workflow%3A"Deploy+Client+Application") action
+2. Click the "Run workflow" button, and select `main` as the branch
+3. Get up and stretch
 
-2. Sign into cloud.gov
-   > cf login -a api.fr.cloud.gov --sso
+## To deploy to the dev/test environment:
 
-Connect to the `dhs-prototype` org and the `usds-prime` space
+Either
 
-3. Deploy
-   > cf push
+1. merge your feature branch into the `staging` branch
+2. push that branch
+
+Or
+
+1. Point your browser to the [Deploy Client Application](actions?query=workflow%3A"Deploy+Client+Application") action
+2. Click the "Run workflow" button, and select your feature branch
+
+In either case, get up and stretch and have a glass of water.
+
+## To restage a deployment in cloud.gov
+
+1. Point your browser to the [Restage Application](actions?query=workflow%3A"Restage+Application") action
+2. Click the "Run workflow" button, and enter either "client" (for the demo deployment) or
+   "staging" (for the dev-test deployment). Yes, that's silly and we will probably change it in the future--if
+   we have, update this text!
 
 # EVERYTHING BELOW THIS IS BOILER-PLACE CREATE-REACT APP
 

--- a/frontend/manifest.yml
+++ b/frontend/manifest.yml
@@ -1,8 +1,12 @@
 applications:
   - name: prime-data-input-client
-    memory: 64M
-    env: # TODO broken: this doesn't actually set the env variables
-      REACT_APP_HOST_ENV: "stage" # used to point to different API/DBs/etc.
+    memory: 32M
+    pushstate: enabled
+    path: build/ # specify where the app is located. The frontend gets built and deployed alongside the backend
+    buildpacks:
+      - https://github.com/cloudfoundry/staticfile-buildpack
+  - name: prime-data-input-staging
+    memory: 32M
     pushstate: enabled
     path: build/ # specify where the app is located. The frontend gets built and deployed alongside the backend
     buildpacks:


### PR DESCRIPTION
* Added a manifest entry for a staging deploy, to distinguish from the demo deploy, and
made only `refs/heads/main` deploy to the demo instance.
* Added a separate "Restage Application" workflow, because we have to do that periodically and it may as well be easy.