### PR TITLE
Fixed routing 404 issue in build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "start-js": "react-scripts start",
     "prebuild": "npm run-script compile-scss",
     "build": "react-scripts build",
+    "postbuild": "echo 'pushstate: enabled' > build/Staticfile",
     "lint": "eslint --quiet --ext .js --ext .jsx ./src",
     "test": "react-scripts test --passWithNoTests",
     "eject": "react-scripts eject",


### PR DESCRIPTION
#Issue
https://github.com/CDCgov/prime-central/issues/68

# About
Fixes the annoying issue of the build 404-ing on non-root urls. Tested this by running the build locally and verifying that non-root urls route correctly. Still needs to be tested on stage to verify that ngnix is processing this correctly.

Fix is attributed to @benwarfield-usds and Tim Best for figuring this out on a different project and reusing the lessons here.

Details: https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#pushstate
