### PR TITLE
fixed notification refresh bug, lots of misc refactors and fixes

### DIFF
--- a/frontend/src/app/commonComponents/Expire.jsx
+++ b/frontend/src/app/commonComponents/Expire.jsx
@@ -1,9 +1,8 @@
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
-const Expire = (props) => {
+const Expire = ({ onExpire, children, delay }) => {
   const [isVisible, setIsVisible] = useState(true);
-  const { onExpire, children, delay } = { ...props };
 
   useEffect(() => {
     setIsVisible(true);

--- a/frontend/src/app/fakeData/patients.js
+++ b/frontend/src/app/fakeData/patients.js
@@ -1,7 +1,7 @@
 // dummy responses for async queries
 export const demoPatients = [
   {
-    patientId: "abc123",
+    patientId: "patientId1",
     firstName: "Edward",
     middleName: "",
     lastName: "Teach",
@@ -10,7 +10,7 @@ export const demoPatients = [
     phone: "(123) 456-7890",
   },
   {
-    patientId: "def456",
+    patientId: "patientId2",
     firstName: "James",
     middleName: "D.",
     lastName: "Flint",
@@ -19,7 +19,7 @@ export const demoPatients = [
     phone: "(321) 546-7890",
   },
   {
-    patientId: "ghi789",
+    patientId: "patientId3",
     firstName: "John",
     middleName: "'Long'",
     lastName: "Silver",
@@ -31,8 +31,8 @@ export const demoPatients = [
 
 // dummy initial data to populate redux
 export const initialPatientState = {
-  abc123: {
-    patientId: "abc123",
+  patientId1: {
+    patientId: "patientId1",
     firstName: "Edward",
     middleName: "",
     lastName: "Teach",
@@ -40,8 +40,8 @@ export const initialPatientState = {
     address: "123 Plank St, Nassau",
     phone: "(123) 456-7890",
   },
-  def456: {
-    patientId: "def456",
+  patientId2: {
+    patientId: "patientId2",
     firstName: "James",
     middleName: "D.",
     lastName: "Flint",
@@ -49,8 +49,8 @@ export const initialPatientState = {
     address: "456 Plank St, Nassau",
     phone: "(321) 546-7890",
   },
-  ghi789: {
-    patientId: "ghi789",
+  patientId3: {
+    patientId: "patientId3",
     firstName: "John",
     middleName: "'Long'",
     lastName: "Silver",

--- a/frontend/src/app/fakeData/testResults.js
+++ b/frontend/src/app/fakeData/testResults.js
@@ -1,15 +1,2 @@
-// maps patientID to testResult info
-export const initialTestResultsState = {
-  abc123: {
-    result: null,
-    deviceId: null,
-  },
-  def456: {
-    result: null,
-    deviceId: null,
-  },
-  ghi789: {
-    result: null,
-    deviceId: null,
-  },
-};
+// maps patientID to array of TestResults
+export const initialTestResultsState = {};

--- a/frontend/src/app/patients/patientSelectors.js
+++ b/frontend/src/app/patients/patientSelectors.js
@@ -5,7 +5,7 @@ export const getPatients = (state) => state.patients;
 
 // gets a single patient by its id
 export const getPatientById = (patientId) =>
-  createSelector(getPatients, (patients) => patients[patientId]);
+  createSelector(getPatients, (patients) => patients[patientId] || null);
 
 // gets multiple patients given an array of patientIds
 export const getPatientsByIds = (patientIds) =>

--- a/frontend/src/app/testQueue/QueueItem.jsx
+++ b/frontend/src/app/testQueue/QueueItem.jsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useState } from "react";
+import { useDispatch } from "react-redux";
 
 import LabeledText from "../commonComponents//LabeledText";
 import Dropdown from "../commonComponents//Dropdown";
 import Button from "../commonComponents/Button";
 import TestResultInputForm from "../testResults/TestResultInputForm";
 import { patientPropType } from "../propTypes";
-import { getTestResultById } from "../testResults/testResultsSelector";
 import { removePatientFromQueue } from "./state/testQueueActions";
 import { submitTestResult } from "../testResults/state/testResultActions";
 import { DEVICES } from "../devices/constants";
@@ -16,12 +15,6 @@ const QueueItem = ({ patient }) => {
 
   const [deviceId, updateDeviceId] = useState(null);
   const [testResultValue, updateTestResultValue] = useState(null);
-
-  const testResult = useSelector(getTestResultById(patient.patientId));
-  useEffect(() => {
-    updateDeviceId(testResult.deviceId);
-    updateTestResultValue(testResult.result);
-  }, [testResult]);
 
   const onTestResultSubmit = (e) => {
     e.preventDefault();

--- a/frontend/src/app/testQueue/QueueNotification.jsx
+++ b/frontend/src/app/testQueue/QueueNotification.jsx
@@ -1,44 +1,34 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { clearNotification } from "./state/testQueueActions";
 
 import Alert from "../commonComponents/Alert";
 import { getPatientById } from "../patients/patientSelectors";
-import { QUEUE_NOTIFICATION_TYPES } from "./constants";
-import { displayFullName } from "../utils";
+import { QUEUE_NOTIFICATION_TYPES, ALERT_CONTENT } from "./constants";
+import Expire from "../commonComponents/Expire";
+import { getQueueNotification } from "../testQueue/testQueueSelectors";
 
-const ALERT_CONTENT = {
-  [QUEUE_NOTIFICATION_TYPES.ADDED_TO_QUEUE__SUCCESS]: (patient) => {
-    return {
-      type: "success",
-      title: `${displayFullName(
-        patient.firstName,
-        patient.middleName,
-        patient.lastName
-      )} was added to the queue`,
-      body: "Newly added patients go to the bottom of the queue",
-    };
-  },
-  [QUEUE_NOTIFICATION_TYPES.SUBMITTED_RESULT__SUCCESS]: (patient) => {
-    return {
-      type: "success",
-      title: `Result was saved and reported for ${displayFullName(
-        patient.firstName,
-        patient.middleName,
-        patient.lastName
-      )}.`,
-      body: "See results to review past test results",
-    };
-  },
-};
-
-const QueueNotification = ({ notification }) => {
+const QueueNotification = () => {
+  const notification = useSelector(getQueueNotification);
   const { notificationType, patientId } = { ...notification };
   const patient = useSelector(getPatientById(patientId));
 
-  let { type, title, body } = { ...ALERT_CONTENT[notificationType](patient) };
+  const dispatch = useDispatch();
+  const onNotificationExpire = () => {
+    dispatch(clearNotification());
+  };
+  const shouldDisplay = notification && Object.keys(notification).length > 0;
+  if (!shouldDisplay) {
+    return null;
+  }
 
-  return <Alert type={type} body={body} title={title} />;
+  let { type, title, body } = { ...ALERT_CONTENT[notificationType](patient) };
+  return (
+    <Expire delay={3000} onExpire={onNotificationExpire}>
+      <Alert type={type} body={body} title={title} />
+    </Expire>
+  );
 };
 
 QueueNotification.propTypes = {

--- a/frontend/src/app/testQueue/TestQueue.jsx
+++ b/frontend/src/app/testQueue/TestQueue.jsx
@@ -1,22 +1,15 @@
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
 import { testResultPropType } from "../propTypes";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 
-import {
-  getDetailedPatientsInTestQueue,
-  getQueueNotification,
-} from "../testQueue/testQueueSelectors";
-import { clearNotification } from "./state/testQueueActions";
+import { getDetailedPatientsInTestQueue } from "../testQueue/testQueueSelectors";
 import AddToQueue from "./addToQueue/AddToQueue";
-import Expire from "../commonComponents/Expire";
 import QueueItem from "./QueueItem";
 import QueueNotification from "./QueueNotification";
 
 const TestQueue = () => {
   const patients = useSelector(getDetailedPatientsInTestQueue);
-  const notification = useSelector(getQueueNotification);
-  const dispatch = useDispatch();
 
   let shouldRenderQueue = Object.keys(patients).length > 0;
   const createQueueItems = (patients) =>
@@ -35,18 +28,6 @@ const TestQueue = () => {
       </React.Fragment>
     );
 
-  const onNotificationExpire = () => {
-    dispatch(clearNotification());
-  };
-
-  const shouldShowAlert = notification && Object.keys(notification).length > 0;
-
-  const alert = shouldShowAlert ? (
-    <Expire delay={3000} onExpire={onNotificationExpire}>
-      <QueueNotification notification={notification} />
-    </Expire>
-  ) : null;
-
   return (
     <main className="prime-home">
       <div className="grid-container">
@@ -54,7 +35,9 @@ const TestQueue = () => {
           <AddToQueue />
           {createQueueItems(patients)}
         </div>
-        <div className="grid-row">{alert}</div>
+        <div className="grid-row">
+          <QueueNotification />
+        </div>
       </div>
     </main>
   );

--- a/frontend/src/app/testQueue/constants.js
+++ b/frontend/src/app/testQueue/constants.js
@@ -1,4 +1,31 @@
+import { displayFullName } from "../utils";
+
 export const QUEUE_NOTIFICATION_TYPES = {
   ADDED_TO_QUEUE__SUCCESS: 1,
   SUBMITTED_RESULT__SUCCESS: 2,
+};
+
+export const ALERT_CONTENT = {
+  [QUEUE_NOTIFICATION_TYPES.ADDED_TO_QUEUE__SUCCESS]: (patient) => {
+    return {
+      type: "success",
+      title: `${displayFullName(
+        patient.firstName,
+        patient.middleName,
+        patient.lastName
+      )} was added to the queue`,
+      body: "Newly added patients go to the bottom of the queue",
+    };
+  },
+  [QUEUE_NOTIFICATION_TYPES.SUBMITTED_RESULT__SUCCESS]: (patient) => {
+    return {
+      type: "success",
+      title: `Result was saved and reported for ${displayFullName(
+        patient.firstName,
+        patient.middleName,
+        patient.lastName
+      )}.`,
+      body: "See results to review past test results",
+    };
+  },
 };

--- a/frontend/src/app/testQueue/state/testQueueActions.js
+++ b/frontend/src/app/testQueue/state/testQueueActions.js
@@ -1,3 +1,4 @@
+import moment from "moment";
 import {
   TEST_QUEUE__ADD_PATIENT,
   TEST_QUEUE__REMOVE_PATIENT,
@@ -12,6 +13,7 @@ const _addPatientToQueue = (patientId) => {
     type: TEST_QUEUE__ADD_PATIENT,
     payload: {
       patientId,
+      dateAdded: moment().toISOString(),
     },
   };
 };

--- a/frontend/src/app/testQueue/state/testQueueReducer.jsx
+++ b/frontend/src/app/testQueue/state/testQueueReducer.jsx
@@ -1,4 +1,3 @@
-import moment from "moment";
 import {
   TEST_QUEUE__ADD_PATIENT,
   TEST_QUEUE__REMOVE_PATIENT,
@@ -9,14 +8,13 @@ import {
 export default (state = {}, action) => {
   switch (action.type) {
     case TEST_QUEUE__ADD_PATIENT: {
-      const patientId = action.payload.patientId;
+      const { patientId, dateAdded } = { ...action.payload };
       return {
         ...state,
         patients: {
           ...state.patients,
           [patientId]: {
-            isInQueue: true,
-            added: moment(),
+            dateAdded,
           },
         },
       };
@@ -45,7 +43,7 @@ export default (state = {}, action) => {
     case TEST_QUEUE__CLEAR_NOTIFICATION: {
       return {
         ...state,
-        notifications: {},
+        notifications: null,
       };
     }
     default:

--- a/frontend/src/app/testQueue/testQueueSelectors.js
+++ b/frontend/src/app/testQueue/testQueueSelectors.js
@@ -7,16 +7,12 @@ const _getPatientsInTestQueue = (state) => state.testQueue.patients;
 export const getQueueNotification = (state) => state.testQueue.notifications;
 
 // returns an array of patientIds that are in the test queue
-// also sorts patients from oldest to newst
-// ie: [patientID1, patientId3, patientId4]
+// also sorts patients from oldest to newest
 const _getPatientIdsInTestQueue = createSelector(
   _getPatientsInTestQueue,
   (patients) => {
     return Object.keys(patients)
-      .filter(
-        (patientId) => patients[patientId] && patients[patientId].isInQueue
-      )
-      .sort((a, b) => patients[a].added - patients[b].added);
+      .sort((a, b) => patients[a].dateAdded - patients[b].dateAdded);
   }
 );
 
@@ -25,18 +21,16 @@ const _getPatientIdsInTestQueue = createSelector(
 export const getAllPatientsWithQueueStatus = createSelector(
   getPatients,
   _getPatientsInTestQueue,
-  (patients, testQueuePatients) => {
-    const patientQueueSearchItems = Object.values(patients).map((patient) => {
+  (allPatients, testQueuePatients) => {
+    const patientQueueSearchItems = Object.values(allPatients).map((patient) => {
       let { firstName, middleName, lastName, birthDate, patientId } = {
         ...patient,
       };
-      let isInQueue =
-        testQueuePatients[patientId] && testQueuePatients[patientId].isInQueue;
       return {
         displayName: displayFullName(firstName, middleName, lastName),
         birthDate,
         patientId,
-        isInQueue,
+        isInQueue: patientId in testQueuePatients,
       };
     });
     return patientQueueSearchItems;

--- a/frontend/src/app/testResults/state/testResultActions.js
+++ b/frontend/src/app/testResults/state/testResultActions.js
@@ -1,9 +1,5 @@
-// import { getTestResult } from "../../query/testResults";
-import {
-  // TEST_RESULT__REQUEST,
-  // TEST_RESULT__RECEIVED,
-  TEST_RESULT__SUBMIT,
-} from "./testResultActionTypes";
+import moment from "moment";
+import { TEST_RESULT__SUBMIT } from "./testResultActionTypes";
 
 import {
   removePatientFromQueue,
@@ -12,24 +8,6 @@ import {
 
 import { QUEUE_NOTIFICATION_TYPES } from "../../testQueue/constants";
 
-// used to signal that a request is being made
-// const requestTestResult = (patientId) => {
-//   return {
-//     type: TEST_RESULT__REQUEST,
-//     payload: patientId,
-//   };
-// };
-
-// const receivedTestResult = (patientId, testResult) => {
-//   return {
-//     type: TEST_RESULT__RECEIVED,
-//     payload: {
-//       testResult,
-//       patientId,
-//     },
-//   };
-// };
-
 const _submitTestResult = (patientId, testResultInfo) => {
   return {
     type: TEST_RESULT__SUBMIT,
@@ -37,6 +15,7 @@ const _submitTestResult = (patientId, testResultInfo) => {
       patientId,
       deviceId: testResultInfo.deviceId,
       result: testResultInfo.testResultValue,
+      dateTested: moment().toISOString(),
     },
   };
 };

--- a/frontend/src/app/testResults/state/testResultReducer.js
+++ b/frontend/src/app/testResults/state/testResultReducer.js
@@ -1,21 +1,21 @@
-import {
-  // TEST_RESULT__REQUEST,
-  // TEST_RESULT__RECEIVED,
-  TEST_RESULT__SUBMIT,
-} from "./testResultActionTypes";
+import { TEST_RESULT__SUBMIT } from "./testResultActionTypes";
 
 const initialState = {};
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case TEST_RESULT__SUBMIT:
-      const { patientId, deviceId, result } = { ...action.payload };
+      const { patientId, deviceId, result, dateTested } = { ...action.payload };
+      const allTestResults = state[patientId] ? [...state[patientId]] : [];
+      const newTestResult = {
+        result,
+        deviceId,
+        dateTested
+      };
+      allTestResults.push(newTestResult);
       return {
         ...state,
-        [patientId]: {
-          result,
-          deviceId,
-        },
+        [patientId]: allTestResults,
       };
     default:
       return state;


### PR DESCRIPTION
# Issue
https://github.com/CDCgov/prime-central/issues/53

# About
This contains several misc small fixes that probably should've been separate PRs:

1. squashed notification reset bug:
  - bug description: when a patient is added to the queue, an alert is displayed notifying that the patient was added to the queue successfully. When this alert disappears, the patient added to the queue re-renders (it shouldn't), wiping any decisions made.
 - This wasn't caught before because notifications only last for 3 seconds and it was unlikely someone made any inputs in this period. QA would've caught this
2. squash stale add-to-queue bug:
  - bug description: when a patient is added to the queue, their test result was pre-populated with their last test result. After the fix, all patients added to the queue have no pre-populated fields
 - this wasn't really a bug; rather, it was assumption made from the mocks. The solution is also an assumption, but it seems to make more sense to me so I'm rolling with it.
3. added `dateAdded` field to testResults so we can render test history and sort by date
4. made some misc refactors. This is how the current redux store looks:

<img width="356" alt="Screen Shot 2020-10-24 at 1 36 53 PM" src="https://user-images.githubusercontent.com/35268641/97093210-e6069680-15fe-11eb-8eec-8315889b8598.png">

## Unanswered Question
- can there be multiple notifications on the page at once? ie: what if you rapidly add patients to the queue before the previous notification disappears? If so, how should we render notifications?
  - Right now, any new notification overwrites the old one, so only the newest notification is displayed.