### PR TITLE
#59 clear now clears device selection

### DIFF
--- a/frontend/src/app/testQueue/QueueItem.jsx
+++ b/frontend/src/app/testQueue/QueueItem.jsx
@@ -39,6 +39,12 @@ const QueueItem = ({ patient, devices }) => {
     updateTestResultValue(newTestResultValue);
   };
 
+  const onClearClick = (e) => {
+    e.preventDefault();
+    onTestResultChange(null);
+    updateDeviceId(null);
+  };
+
   const openAoeModal = () => {
     updateIsAoeModalOpen(true);
   };
@@ -125,6 +131,7 @@ const QueueItem = ({ patient, devices }) => {
               testResultValue={testResultValue}
               onSubmit={onTestResultSubmit}
               onChange={onTestResultChange}
+              onClearClick={onClearClick}
             />
           </div>
         </div>

--- a/frontend/src/app/testResults/TestResultInputForm.jsx
+++ b/frontend/src/app/testResults/TestResultInputForm.jsx
@@ -7,12 +7,12 @@ import Anchor from "../commonComponents/Anchor";
 import { COVID_RESULTS } from "../constants";
 import { v4 as uuidv4 } from "uuid";
 
-const TestResultInputForm = ({ testResultValue, onSubmit, onChange }) => {
-  const onClearClick = (e) => {
-    e.preventDefault();
-    onChange(null);
-  };
-
+const TestResultInputForm = ({
+  testResultValue,
+  onSubmit,
+  onChange,
+  onClearClick,
+}) => {
   const testResultForm = (
     <React.Fragment>
       <RadioGroup


### PR DESCRIPTION
I moved onClearClick out of the input form and into the parent where it could also clear the device. Looks like this works and didn't break anything, but please double check my logic?

https://github.com/CDCgov/prime-central/issues/59
```
Allow the user to clear the test result (before submitting) (Neil: atm, this doesn't clear the test device, only the test result). Also, should it clear the AOE questionaire, or does that need its own "clear" button"?
```