### PR TITLE
Added: Settings Page + Device Mgmt

### DIFF
--- a/frontend/src/app/OrganizationView/OrganizationHomeContainer.jsx
+++ b/frontend/src/app/OrganizationView/OrganizationHomeContainer.jsx
@@ -10,6 +10,7 @@ import {
 import TestResultsList from "../testResults/TestResultsList";
 import TestQueue from "../testQueue/TestQueue";
 import ManagePatients from "../patients/ManagePatients";
+import Settings from "../Settings/Settings";
 
 const OrganizationHomeContainer = () => {
   let match = useRouteMatch();
@@ -34,6 +35,12 @@ const OrganizationHomeContainer = () => {
           path={`${match.path}/patients`}
           render={() => {
             return <ManagePatients />;
+          }}
+        />
+        <Route
+          path={`${match.path}/settings`}
+          render={() => {
+            return <Settings />;
           }}
         />
         <Route path={`${match.path}/`}>

--- a/frontend/src/app/Settings/DeviceSettings.jsx
+++ b/frontend/src/app/Settings/DeviceSettings.jsx
@@ -1,19 +1,11 @@
-import React, { useState } from "react";
-import { useSelector } from "react-redux";
+import React from "react";
 import { v4 as uuidv4 } from "uuid";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
+import Button from "../commonComponents/Button";
 import Dropdown from "../commonComponents//Dropdown";
-import { getDevicesArray } from "../devices/deviceSelectors";
 import { DEVICE_TYPES } from "../devices/constants";
-
-const generateDeviceSettings = (devices) => {
-  return devices.reduce((acc, device) => {
-    let name = `device-${uuidv4()}`; // assign a dynamic name to each device
-    acc[name] = device;
-    return acc;
-  }, {});
-};
+import RadioGroup from "../commonComponents/RadioGroup";
 
 const dropdownOptions = Object.entries(DEVICE_TYPES).map(
   ([deviceId, displayName]) => ({
@@ -22,13 +14,11 @@ const dropdownOptions = Object.entries(DEVICE_TYPES).map(
   })
 );
 
-const DeviceSettings = () => {
-  const devices = useSelector(getDevicesArray);
-
-  const [deviceSettings, updateDeviceSettings] = useState(
-    generateDeviceSettings(devices)
-  );
-
+const DeviceSettings = ({
+  deviceSettings,
+  updateDeviceSettings,
+  addDevice,
+}) => {
   const onDeviceChange = (e) => {
     let changedDeviceName = e.target.name;
     let newDeviceId = e.target.value;
@@ -43,6 +33,27 @@ const DeviceSettings = () => {
     updateDeviceSettings(newDeviceSettings);
   };
 
+  const onDefaultChange = (e) => {
+    let changedDeviceName = e.target.name;
+
+    let isDefault = !deviceSettings[changedDeviceName].isDefault;
+    let newDeviceSettings = {};
+
+    Object.entries(deviceSettings).forEach(([name, device]) => {
+      newDeviceSettings[name] = {
+        ...device,
+        isDefault: false,
+      };
+    });
+
+    newDeviceSettings[changedDeviceName] = {
+      ...deviceSettings[changedDeviceName],
+      isDefault,
+    };
+
+    updateDeviceSettings(newDeviceSettings);
+  };
+
   const onDeviceRemove = (deviceName) => {
     let newDeviceSettings = {
       ...deviceSettings,
@@ -53,7 +64,7 @@ const DeviceSettings = () => {
 
   const renderDevicesTable = () => {
     if (Object.keys(deviceSettings).length === 0) {
-      return <p> There are curreently no devices </p>;
+      return <p> There are currently no devices </p>;
     }
     let deviceRows = Object.entries(deviceSettings).map(([name, device]) => {
       let dropdown = (
@@ -74,7 +85,20 @@ const DeviceSettings = () => {
       return (
         <tr key={uuidv4()}>
           <td>{dropdown}</td>
-          <td>is default</td>
+          <td>
+            <RadioGroup
+              type="checkbox"
+              onChange={onDefaultChange}
+              buttons={[
+                {
+                  value: "true",
+                  label: "Set as Default",
+                },
+              ]}
+              selectedRadio={device.isDefault ? "true" : "false"}
+              name={name}
+            />
+          </td>
           <td>{removeDevice}</td>
         </tr>
       );
@@ -101,6 +125,15 @@ const DeviceSettings = () => {
             <h3> Manage Devices </h3>
           </div>
           <div className="usa-card__body">{renderDevicesTable()}</div>
+          <div className="usa-card__footer">
+            <Button
+              onClick={addDevice}
+              type="submit"
+              outline
+              label="Add Another Device"
+              icon="plus"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/Settings/DeviceSettings.jsx
+++ b/frontend/src/app/Settings/DeviceSettings.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { v4 as uuidv4 } from "uuid";
+// import { useSelector, useDispatch } from "react-redux";
+// import { clearNotification } from "./state/testQueueActions";
+
+// import Alert from "../commonComponents/Alert";
+// import { getPatientById } from "../patients/patientSelectors";
+// import Expire from "../commonComponents/Expire";
+// import { getQueueNotification } from "../testQueue/testQueueSelectors";
+// import Devices from "./Devices";
+import { getDevicesArray } from "../devices/deviceSelectors";
+import Dropdown from "../commonComponents//Dropdown";
+import { DEVICE_TYPES } from "../devices/constants";
+import { useEffect } from "react";
+
+const generateDevieSettings = (devices) => {
+  return devices.reduce((acc, device) => {
+    let name = `device-${uuidv4()}`; // assign a dynamic name to each device
+    acc[name] = device;
+    return acc;
+  }, {});
+};
+
+const DeviceSettings = () => {
+  const devices = useSelector(getDevicesArray);
+
+  const [deviceSettings, updateDeviceSettings] = useState(
+    generateDevieSettings(devices)
+  );
+
+  const onDeviceChange = (e) => {
+    let changedDeviceName = e.target.name;
+    let newDeviceId = e.target.value;
+    let newDeviceSettings = {
+      ...deviceSettings,
+      [changedDeviceName]: {
+        ...deviceSettings[changedDeviceName],
+        deviceId: newDeviceId,
+        displayName: DEVICE_TYPES[newDeviceId],
+      },
+    };
+    updateDeviceSettings(newDeviceSettings);
+  };
+
+  const dropdownOptions = Object.entries(DEVICE_TYPES).map(
+    ([deviceId, displayName]) => ({
+      label: displayName,
+      value: deviceId,
+    })
+  );
+
+  const renderDevicesTable = () => {
+    if (Object.keys(deviceSettings).length === 0) {
+      return <p> There are curreently no devices </p>;
+    }
+    let deviceRows = Object.entries(deviceSettings).map(([name, device]) => {
+      let dropdown = (
+        <Dropdown
+          options={dropdownOptions}
+          name={name}
+          selectedValue={device.deviceId}
+          onChange={onDeviceChange}
+        />
+      );
+      return (
+        <tr key={uuidv4()}>
+          <td>{dropdown}</td>
+          <td>is default</td>
+          <td>trash</td>
+        </tr>
+      );
+    });
+    return (
+      <table className="usa-table usa-table--borderless">
+        <thead>
+          <tr>
+            <th scope="col">Device Type</th>
+            <th scope="col"></th>
+            <th scope="col">Action</th>
+          </tr>
+        </thead>
+        <tbody>{deviceRows}</tbody>
+      </table>
+    );
+  };
+
+  return (
+    <div className="grid-container">
+      <div className="grid-row">
+        <div className="prime-container usa-card__container">
+          <div className="usa-card__header">
+            <h3> Manage Devices </h3>
+          </div>
+          <div className="usa-card__body">{renderDevicesTable()}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeviceSettings;

--- a/frontend/src/app/Settings/DeviceSettings.jsx
+++ b/frontend/src/app/Settings/DeviceSettings.jsx
@@ -1,20 +1,13 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { v4 as uuidv4 } from "uuid";
-// import { useSelector, useDispatch } from "react-redux";
-// import { clearNotification } from "./state/testQueueActions";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-// import Alert from "../commonComponents/Alert";
-// import { getPatientById } from "../patients/patientSelectors";
-// import Expire from "../commonComponents/Expire";
-// import { getQueueNotification } from "../testQueue/testQueueSelectors";
-// import Devices from "./Devices";
-import { getDevicesArray } from "../devices/deviceSelectors";
 import Dropdown from "../commonComponents//Dropdown";
+import { getDevicesArray } from "../devices/deviceSelectors";
 import { DEVICE_TYPES } from "../devices/constants";
-import { useEffect } from "react";
 
-const generateDevieSettings = (devices) => {
+const generateDeviceSettings = (devices) => {
   return devices.reduce((acc, device) => {
     let name = `device-${uuidv4()}`; // assign a dynamic name to each device
     acc[name] = device;
@@ -22,11 +15,18 @@ const generateDevieSettings = (devices) => {
   }, {});
 };
 
+const dropdownOptions = Object.entries(DEVICE_TYPES).map(
+  ([deviceId, displayName]) => ({
+    label: displayName,
+    value: deviceId,
+  })
+);
+
 const DeviceSettings = () => {
   const devices = useSelector(getDevicesArray);
 
   const [deviceSettings, updateDeviceSettings] = useState(
-    generateDevieSettings(devices)
+    generateDeviceSettings(devices)
   );
 
   const onDeviceChange = (e) => {
@@ -43,12 +43,13 @@ const DeviceSettings = () => {
     updateDeviceSettings(newDeviceSettings);
   };
 
-  const dropdownOptions = Object.entries(DEVICE_TYPES).map(
-    ([deviceId, displayName]) => ({
-      label: displayName,
-      value: deviceId,
-    })
-  );
+  const onDeviceRemove = (deviceName) => {
+    let newDeviceSettings = {
+      ...deviceSettings,
+    };
+    delete newDeviceSettings[deviceName];
+    updateDeviceSettings(newDeviceSettings);
+  };
 
   const renderDevicesTable = () => {
     if (Object.keys(deviceSettings).length === 0) {
@@ -63,11 +64,18 @@ const DeviceSettings = () => {
           onChange={onDeviceChange}
         />
       );
+
+      let removeDevice = (
+        <div onClick={() => onDeviceRemove(name)}>
+          <FontAwesomeIcon icon={"trash"} className={"prime-red-icon"} />
+        </div>
+      );
+
       return (
         <tr key={uuidv4()}>
           <td>{dropdown}</td>
           <td>is default</td>
-          <td>trash</td>
+          <td>{removeDevice}</td>
         </tr>
       );
     });

--- a/frontend/src/app/Settings/Settings.jsx
+++ b/frontend/src/app/Settings/Settings.jsx
@@ -1,27 +1,9 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
-import { v4 as uuidv4 } from "uuid";
 
 import DeviceSettings from "./DeviceSettings";
 import { getDevicesArray } from "../devices/deviceSelectors";
-import { DEVICE_TYPES } from "../devices/constants";
-
-const generateDeviceSettings = (devices) => {
-  return devices.reduce((acc, device) => {
-    let name = `device-${uuidv4()}`; // assign a dynamic name to each device
-    acc[name] = device;
-    return acc;
-  }, {});
-};
-
-const generateDevice = () => {
-  let deviceId = Object.keys(DEVICE_TYPES)[0]; // randomlly pick one
-  return {
-    deviceId,
-    displayName: DEVICE_TYPES[deviceId],
-    isDefault: false,
-  };
-};
+import { generateDeviceSettings } from "../devices/utils";
 
 const Settings = () => {
   const devices = useSelector(getDevicesArray);
@@ -30,14 +12,6 @@ const Settings = () => {
     generateDeviceSettings(devices)
   );
 
-  const addDevice = (deviceId) => {
-    let name = `device-${uuidv4()}`;
-    let newDeviceSettings = {
-      ...deviceSettings,
-      [name]: generateDevice(deviceId),
-    };
-    updateDeviceSettings(newDeviceSettings);
-  };
   return (
     <main className="prime-home">
       <div className="grid-container">
@@ -46,7 +20,6 @@ const Settings = () => {
       <DeviceSettings
         deviceSettings={deviceSettings}
         updateDeviceSettings={updateDeviceSettings}
-        addDevice={addDevice}
       />
     </main>
   );

--- a/frontend/src/app/Settings/Settings.jsx
+++ b/frontend/src/app/Settings/Settings.jsx
@@ -1,33 +1,53 @@
-import React from "react";
-// import { useSelector, useDispatch } from "react-redux";
-// import { clearNotification } from "./state/testQueueActions";
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { v4 as uuidv4 } from "uuid";
 
-// import Alert from "../commonComponents/Alert";
-// import { getPatientById } from "../patients/patientSelectors";
-// import Expire from "../commonComponents/Expire";
-// import { getQueueNotification } from "../testQueue/testQueueSelectors";
 import DeviceSettings from "./DeviceSettings";
+import { getDevicesArray } from "../devices/deviceSelectors";
+import { DEVICE_TYPES } from "../devices/constants";
+
+const generateDeviceSettings = (devices) => {
+  return devices.reduce((acc, device) => {
+    let name = `device-${uuidv4()}`; // assign a dynamic name to each device
+    acc[name] = device;
+    return acc;
+  }, {});
+};
+
+const generateDevice = () => {
+  let deviceId = Object.keys(DEVICE_TYPES)[0]; // randomlly pick one
+  return {
+    deviceId,
+    displayName: DEVICE_TYPES[deviceId],
+    isDefault: false,
+  };
+};
+
 const Settings = () => {
-  //   const notification = useSelector(getQueueNotification);
-  //   const { notificationType, patientId } = { ...notification };
-  //   const patient = useSelector(getPatientById(patientId));
+  const devices = useSelector(getDevicesArray);
 
-  //   const dispatch = useDispatch();
-  //   const onNotificationExpire = () => {
-  //     dispatch(clearNotification());
-  //   };
-  //   const shouldDisplay = notification && Object.keys(notification).length > 0;
-  //   if (!shouldDisplay) {
-  //     return null;
-  //   }
+  const [deviceSettings, updateDeviceSettings] = useState(
+    generateDeviceSettings(devices)
+  );
 
-  //   let { type, title, body } = { ...ALERT_CONTENT[notificationType](patient) };
+  const addDevice = (deviceId) => {
+    let name = `device-${uuidv4()}`;
+    let newDeviceSettings = {
+      ...deviceSettings,
+      [name]: generateDevice(deviceId),
+    };
+    updateDeviceSettings(newDeviceSettings);
+  };
   return (
     <main className="prime-home">
       <div className="grid-container">
         <h2>Global Settings</h2>
       </div>
-      <DeviceSettings />
+      <DeviceSettings
+        deviceSettings={deviceSettings}
+        updateDeviceSettings={updateDeviceSettings}
+        addDevice={addDevice}
+      />
     </main>
   );
 };

--- a/frontend/src/app/Settings/Settings.jsx
+++ b/frontend/src/app/Settings/Settings.jsx
@@ -12,15 +12,12 @@ const Settings = () => {
   const dispatch = useDispatch();
   const devices = useSelector(getDevicesArray);
 
-  console.log(devices);
-
   const [deviceSettings, updateDeviceSettings] = useState(
-    generateDeviceSettings(devices)
+    generateDeviceSettings(devices) // TODO: this needs to update with the latest device schema
   );
 
   const onSaveSettings = () => {
     // add other setting state here
-    console.log("saving settings");
     dispatch(updateSettings(deviceSettings));
   };
 

--- a/frontend/src/app/Settings/Settings.jsx
+++ b/frontend/src/app/Settings/Settings.jsx
@@ -6,7 +6,7 @@ import React from "react";
 // import { getPatientById } from "../patients/patientSelectors";
 // import Expire from "../commonComponents/Expire";
 // import { getQueueNotification } from "../testQueue/testQueueSelectors";
-
+import DeviceSettings from "./DeviceSettings";
 const Settings = () => {
   //   const notification = useSelector(getQueueNotification);
   //   const { notificationType, patientId } = { ...notification };
@@ -24,7 +24,10 @@ const Settings = () => {
   //   let { type, title, body } = { ...ALERT_CONTENT[notificationType](patient) };
   return (
     <main className="prime-home">
-      <h1> Settings Page</h1>
+      <div className="grid-container">
+        <h2>Global Settings</h2>
+      </div>
+      <DeviceSettings />
     </main>
   );
 };

--- a/frontend/src/app/Settings/Settings.jsx
+++ b/frontend/src/app/Settings/Settings.jsx
@@ -1,21 +1,40 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import DeviceSettings from "./DeviceSettings";
 import { getDevicesArray } from "../devices/deviceSelectors";
 import { generateDeviceSettings } from "../devices/utils";
+import Button from "../commonComponents/Button";
+import { updateSettings } from "../Settings/state/settingsActions";
 
 const Settings = () => {
+  const dispatch = useDispatch();
   const devices = useSelector(getDevicesArray);
+
+  console.log(devices);
 
   const [deviceSettings, updateDeviceSettings] = useState(
     generateDeviceSettings(devices)
   );
 
+  const onSaveSettings = () => {
+    // add other setting state here
+    console.log("saving settings");
+    dispatch(updateSettings(deviceSettings));
+  };
+
   return (
     <main className="prime-home">
       <div className="grid-container">
-        <h2>Global Settings</h2>
+        <div className="grid-row">
+          <h2>Global Settings</h2>
+          <Button
+            type="button"
+            onClick={onSaveSettings}
+            label="Save Settings"
+          />
+        </div>
       </div>
       <DeviceSettings
         deviceSettings={deviceSettings}

--- a/frontend/src/app/Settings/Settings.jsx
+++ b/frontend/src/app/Settings/Settings.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+// import { useSelector, useDispatch } from "react-redux";
+// import { clearNotification } from "./state/testQueueActions";
+
+// import Alert from "../commonComponents/Alert";
+// import { getPatientById } from "../patients/patientSelectors";
+// import Expire from "../commonComponents/Expire";
+// import { getQueueNotification } from "../testQueue/testQueueSelectors";
+
+const Settings = () => {
+  //   const notification = useSelector(getQueueNotification);
+  //   const { notificationType, patientId } = { ...notification };
+  //   const patient = useSelector(getPatientById(patientId));
+
+  //   const dispatch = useDispatch();
+  //   const onNotificationExpire = () => {
+  //     dispatch(clearNotification());
+  //   };
+  //   const shouldDisplay = notification && Object.keys(notification).length > 0;
+  //   if (!shouldDisplay) {
+  //     return null;
+  //   }
+
+  //   let { type, title, body } = { ...ALERT_CONTENT[notificationType](patient) };
+  return (
+    <main className="prime-home">
+      <h1> Settings Page</h1>
+    </main>
+  );
+};
+
+export default Settings;

--- a/frontend/src/app/Settings/state/settingsActionTypes.js
+++ b/frontend/src/app/Settings/state/settingsActionTypes.js
@@ -1,0 +1,1 @@
+export const SETTINGS__UPDATE_SETTINGS = "settings/updateSettings";

--- a/frontend/src/app/Settings/state/settingsActions.js
+++ b/frontend/src/app/Settings/state/settingsActions.js
@@ -1,4 +1,4 @@
-import { updateDeviceSettings } from "../../devices/state/devicesActions";
+import { setDeviceSettings } from "../../devices/state/devicesActions";
 import { SETTINGS__UPDATE_SETTINGS } from "./settingsActionTypes";
 
 const _updateSettings = () => {
@@ -10,6 +10,6 @@ const _updateSettings = () => {
 export const updateSettings = (deviceSettings) => {
   return (dispatch) => {
     dispatch(_updateSettings());
-    dispatch(updateDeviceSettings(deviceSettings));
+    dispatch(setDeviceSettings(deviceSettings));
   };
 };

--- a/frontend/src/app/Settings/state/settingsActions.js
+++ b/frontend/src/app/Settings/state/settingsActions.js
@@ -1,0 +1,15 @@
+import { updateDeviceSettings } from "../../devices/state/devicesActions";
+import { SETTINGS__UPDATE_SETTINGS } from "./settingsActionTypes";
+
+const _updateSettings = () => {
+  return {
+    type: SETTINGS__UPDATE_SETTINGS,
+  };
+};
+
+export const updateSettings = (deviceSettings) => {
+  return (dispatch) => {
+    dispatch(_updateSettings());
+    dispatch(updateDeviceSettings(deviceSettings));
+  };
+};

--- a/frontend/src/app/commonComponents/Dropdown.jsx
+++ b/frontend/src/app/commonComponents/Dropdown.jsx
@@ -17,7 +17,7 @@ const Dropdown = ({ options, label, name, onChange, selectedValue }) => {
       </label>
       <select
         className="usa-select"
-        name={id}
+        name={name}
         id={id}
         onChange={onChange}
         value={selectedValue || ""}

--- a/frontend/src/app/commonComponents/Header.jsx
+++ b/frontend/src/app/commonComponents/Header.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link, NavLink } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const Header = ({ organizationId }) => {
   return (
@@ -46,6 +47,21 @@ const Header = ({ organizationId }) => {
                 }}
               >
                 Manage Patients
+              </NavLink>
+            </li>
+          </ul>
+        </nav>
+        <nav aria-label="Primary navigation" className="usa-nav prime-nav">
+          <ul className="usa-nav__primary usa-accordion">
+            <li className="usa-nav__primary-item">
+              <NavLink
+                to={`/organization/${organizationId}/settings`}
+                activeClassName="active-nav-item"
+                activeStyle={{
+                  color: "white",
+                }}
+              >
+                <FontAwesomeIcon icon={"cog"} size="2x" />
               </NavLink>
             </li>
           </ul>

--- a/frontend/src/app/commonComponents/RadioGroup.jsx
+++ b/frontend/src/app/commonComponents/RadioGroup.jsx
@@ -10,6 +10,7 @@ const RadioGroup = ({
   disabled,
   horizontal, // should only be used for radio buttons with two options. 3+ options should be vertically stacked
   selectedRadio,
+  type,
   legend,
 }) => {
   // Note: list Affirmations before negations: Yes before No.
@@ -21,20 +22,24 @@ const RadioGroup = ({
       "prime-radio--success": button.value === selectedRadio && button.success,
       "prime-radio--failure": button.value === selectedRadio && button.failure,
     });
+
     return (
       <li className={classNames} key={button.value}>
         <input
-          className="usa-radio__input"
+          className={`usa-${type || "radio"}__input`}
           checked={button.value === selectedRadio}
           id={uuid}
           key={button.value}
           name={name}
           onChange={onChange}
-          type="radio"
+          type={type || "radio"}
           value={button.value}
           disabled={button.disabled || disabled || false}
         />
-        <label className="usa-radio__label prime-radio__label" htmlFor={uuid}>
+        <label
+          className={`usa-${type || "radio"}__label prime-radio__label`}
+          htmlFor={uuid}
+        >
           {button.label}
         </label>
       </li>

--- a/frontend/src/app/devices/constants.js
+++ b/frontend/src/app/devices/constants.js
@@ -1,0 +1,16 @@
+/* 
+A list of device manfactueres
+
+Only these options exist in the market at the moment. 
+
+TODO: the backend should provide this
+TODO: there should be an admin page to add to this list. We would need to manage this so we can map device type <-> device id recognized by PHDs
+*/
+
+export const DEVICE_TYPES = {
+  deviceId1: "Quidel Sofia 2",
+  deviceId2: "BD Veritor",
+  deviceId3: "Abbott Binax Now",
+  deviceId4: "Abbot ID now",
+  deviceId5: "Lumira DX",
+};

--- a/frontend/src/app/devices/state/devicesActionTypes.js
+++ b/frontend/src/app/devices/state/devicesActionTypes.js
@@ -1,0 +1,1 @@
+export const DEVICES__UPDATE_DEVICES = "devices/updateDevices";

--- a/frontend/src/app/devices/state/devicesActionTypes.js
+++ b/frontend/src/app/devices/state/devicesActionTypes.js
@@ -1,1 +1,1 @@
-export const DEVICES__UPDATE_DEVICES = "devices/updateDevices";
+export const DEVICES__SET_DEVICE_SETTINGS = "devices/setDeviceSettings";

--- a/frontend/src/app/devices/state/devicesActions.js
+++ b/frontend/src/app/devices/state/devicesActions.js
@@ -1,14 +1,11 @@
-import moment from "moment";
+import { DEVICES__UPDATE_DEVICES } from "./devicesActionTypes";
 
-// import { QUEUE_NOTIFICATION_TYPES } from "../constants";
-import { DEVICES__ADD_DEVICE } from "./deviecsActionTypes";
-
-const addNewDevice = (patientId) => {
+// this just does a `set` operation
+export const updateDeviceSettings = (deviceSettings) => {
   return {
-    type: DEVICES__ADD_DEVICE,
+    type: DEVICES__UPDATE_DEVICES,
     payload: {
-      patientId,
-      dateAdded: moment().toISOString(),
+      deviceSettings,
     },
   };
 };

--- a/frontend/src/app/devices/state/devicesActions.js
+++ b/frontend/src/app/devices/state/devicesActions.js
@@ -1,9 +1,9 @@
-import { DEVICES__UPDATE_DEVICES } from "./devicesActionTypes";
+import { DEVICES__SET_DEVICE_SETTINGS } from "./devicesActionTypes";
 
-// this just does a `set` operation
-export const updateDeviceSettings = (deviceSettings) => {
+//
+export const setDeviceSettings = (deviceSettings) => {
   return {
-    type: DEVICES__UPDATE_DEVICES,
+    type: DEVICES__SET_DEVICE_SETTINGS,
     payload: {
       deviceSettings,
     },

--- a/frontend/src/app/devices/state/devicesActions.js
+++ b/frontend/src/app/devices/state/devicesActions.js
@@ -1,0 +1,14 @@
+import moment from "moment";
+
+// import { QUEUE_NOTIFICATION_TYPES } from "../constants";
+import { DEVICES__ADD_DEVICE } from "./deviecsActionTypes";
+
+const addNewDevice = (patientId) => {
+  return {
+    type: DEVICES__ADD_DEVICE,
+    payload: {
+      patientId,
+      dateAdded: moment().toISOString(),
+    },
+  };
+};

--- a/frontend/src/app/devices/state/devicesReducer.js
+++ b/frontend/src/app/devices/state/devicesReducer.js
@@ -1,7 +1,11 @@
+import { DEVICES__SET_DEVICE_SETTINGS } from "./devicesActionTypes";
+
 const initialState = {};
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case DEVICES__SET_DEVICE_SETTINGS:
+      return action.payload.deviceSettings;
     default:
       return state;
   }

--- a/frontend/src/app/devices/state/deviecsActionTypes.js
+++ b/frontend/src/app/devices/state/deviecsActionTypes.js
@@ -1,3 +1,0 @@
-export const DEVICES__ADD_DEVICE = "devices/addDevice";
-export const DEVICES__UPDATE_DEVICE = "devices/updateDevice";
-export const DEVICES__REMOVE_DEVICE = "devices/removeDevices";

--- a/frontend/src/app/devices/state/deviecsActionTypes.js
+++ b/frontend/src/app/devices/state/deviecsActionTypes.js
@@ -1,0 +1,3 @@
+export const DEVICES__ADD_DEVICE = "devices/addDevice";
+export const DEVICES__UPDATE_DEVICE = "devices/updateDevice";
+export const DEVICES__REMOVE_DEVICE = "devices/removeDevices";

--- a/frontend/src/app/devices/utils.js
+++ b/frontend/src/app/devices/utils.js
@@ -1,0 +1,19 @@
+import { v4 as uuidv4 } from "uuid";
+import { DEVICE_TYPES } from "./constants";
+
+export const generateDeviceSettings = (devices) => {
+  return devices.reduce((acc, device) => {
+    let name = `device-${uuidv4()}`; // assign a dynamic name to each device
+    acc[name] = device;
+    return acc;
+  }, {});
+};
+
+export const createNewDevice = () => {
+  let deviceId = Object.keys(DEVICE_TYPES)[0]; // doesn't matter, just pick one
+  return {
+    deviceId,
+    displayName: DEVICE_TYPES[deviceId],
+    isDefault: false,
+  };
+};

--- a/frontend/src/app/fakeData/devices.js
+++ b/frontend/src/app/fakeData/devices.js
@@ -1,14 +1,12 @@
+import { DEVICE_TYPES } from "../devices/constants";
+
+let randomDeviceId = Object.keys(DEVICE_TYPES)[0];
+
 export const initialDevicesState = {
-  deviceId1: {
-    displayName: "Abbott - ID NOW", // TODO this is a constant and can be removed from redux
+  [randomDeviceId]: {
+    displayName: DEVICE_TYPES[randomDeviceId],
     deviceManufacturer: "Abbott",
     deviceModel: "ID NOW",
-    isDefault: false,
-  },
-  deviceId2: {
-    displayName: "Abbott - BinaxNOW COVID-19 Ag Card",
-    deviceManufacturer: "Abbott",
-    deviceModel: "BinaxNOW COVID-19 Ag Card",
     isDefault: false,
   },
 };

--- a/frontend/src/app/fakeData/devices.js
+++ b/frontend/src/app/fakeData/devices.js
@@ -7,6 +7,6 @@ export const initialDevicesState = {
     displayName: DEVICE_TYPES[randomDeviceId],
     deviceManufacturer: "Abbott",
     deviceModel: "ID NOW",
-    isDefault: false,
+    isDefault: true,
   },
 };

--- a/frontend/src/app/fakeData/devices.js
+++ b/frontend/src/app/fakeData/devices.js
@@ -1,8 +1,10 @@
 export const initialDevicesState = {
   deviceId1: {
-    displayName: "Abbott ID Now",
+    displayName: "Abbott ID Now", // TODO this is a constant and can be removed from redux
+    isDefault: false,
   },
   deviceId2: {
     displayName: "Abbott ID Later",
+    isDefault: false,
   },
 };

--- a/frontend/src/app/testQueue/QueueItem.jsx
+++ b/frontend/src/app/testQueue/QueueItem.jsx
@@ -18,7 +18,9 @@ const QueueItem = ({ patient, devices }) => {
 
   const [isAoeModalOpen, updateIsAoeModalOpen] = useState(false);
 
-  const [deviceId, updateDeviceId] = useState(null);
+  let defaultDevice = devices.find((device) => device.isDefault); // might be null if no devices have been added to the org
+  let defaultDeviceId = defaultDevice ? defaultDevice.deviceId : null;
+  const [deviceId, updateDeviceId] = useState(defaultDeviceId);
   const [testResultValue, updateTestResultValue] = useState(null);
 
   const onTestResultSubmit = (e) => {

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -76,6 +76,12 @@
   cursor: pointer;
 }
 
+// other buttons
+
+.prime-red-icon {
+  color: color($theme-color-secondary);
+}
+
 // TestResultInputForm
 .prime-test-result-submit {
   margin-left: 1em;

--- a/frontend/src/styles/fontAwesome.js
+++ b/frontend/src/styles/fontAwesome.js
@@ -20,6 +20,7 @@ import {
   faArrowLeft,
   faTimesCircle,
   faCircle,
+  faCog,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(
@@ -41,5 +42,6 @@ library.add(
   faSearch,
   faArrowLeft,
   faTimesCircle,
-  faCircle
+  faCircle,
+  faCog
 );


### PR DESCRIPTION
## Issue
https://github.com/CDCgov/prime-central/issues/93

## Content
- Added a link to the settings page in the header
- User can add new devices, remove existing devices, select a different device, or set any device as the default device (this is optional)
- wired device settings into redux
- updated each patient in the queue to have the default device pre-selected
- modified radio component to also support checklists

## Not included:
- styles
~~- saving the results to redux~~


## Adding device flow:
![devices](https://user-images.githubusercontent.com/35268641/98177693-12000280-1eb0-11eb-9b77-5e1a99abedba.gif)


## Saving device settings
![device-redu](https://user-images.githubusercontent.com/35268641/98212094-f6b8e580-1ef7-11eb-8d9f-1d5c2dedb1c2.gif)

Fixes #