### PR TITLE
Fix multiple dependent spec for patients

### DIFF
--- a/frontend/src/app/patient.schema.json
+++ b/frontend/src/app/patient.schema.json
@@ -116,32 +116,38 @@
     "employedInHealthcare",
     "residentCongregateSetting"
   ],
-  "if": {
-    "properties": {
-      "employedInHealthcare": {
-        "const": {
-          "type": "YES"
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "employedInHealthcare": {
+            "const": {
+              "type": "YES"
+            }
+          }
+        }
+      },
+      "then": {
+        "dependencies": {
+          "employedInHealthcare": ["typeOfHealthcareProfessional"]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "residentCongregateSetting": {
+            "const": {
+              "type": "YES"
+            }
+          }
+        }
+      },
+      "then": {
+        "dependencies": {
+          "residentCongregateSetting": ["patientResidencyType"]
         }
       }
     }
-  },
-  "then": {
-    "dependencies": {
-      "employedInHealthcare": ["typeOfHealthcareProfessional"]
-    }
-  },
-  "if": {
-    "properties": {
-      "residentCongregateSetting": {
-        "const": {
-          "type": "YES"
-        }
-      }
-    }
-  },
-  "then": {
-    "dependencies": {
-      "residentCongregateSetting": ["patientResidencyType"]
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Multiple conditions have to be wrapped, since you can't have two keys named `if` in the same object.

https://json-schema.org/understanding-json-schema/reference/conditionals.html

