### PR TITLE
Add save button and navigation warning for patients

### DIFF
--- a/frontend/src/app/fakeData/patients.js
+++ b/frontend/src/app/fakeData/patients.js
@@ -44,7 +44,7 @@ export const demoPatients = [
 
 // dummy initial data to populate redux
 export const initialPatientState = {
-  patientId1: {
+  "$PATIENT-b3xkhkyxb70": {
     patientId: "$PATIENT-b3xkhkyxb70",
     lookupId: "patientId1",
     firstName: "Edward",
@@ -54,7 +54,7 @@ export const initialPatientState = {
     address: "123 Plank St, Nassau",
     phone: "(123) 456-7890",
   },
-  patientId2: {
+  "$PATIENT-3xpkhkyx51m": {
     patientId: "$PATIENT-3xpkhkyx51m",
     lookupId: "patientId2",
     firstName: "James",
@@ -64,7 +64,7 @@ export const initialPatientState = {
     address: "456 Plank St, Nassau",
     phone: "(321) 546-7890",
   },
-  patientId3: {
+  "$PATIENT-2ockhkyx15k": {
     patientId: "$PATIENT-2ockhkyx15k",
     lookupId: "patientId3",
     firstName: "John",
@@ -74,7 +74,7 @@ export const initialPatientState = {
     address: "789 Plank St, Nassau",
     phone: "(213) 645-7890",
   },
-  patientId4: {
+  "$PATIENT-mh5khkzccs0": {
     patientId: "$PATIENT-mh5khkzccs0",
     lookupId: "patientId4",
     firstName: "Sally",

--- a/frontend/src/app/patients/EditPatient.jsx
+++ b/frontend/src/app/patients/EditPatient.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import {
   PATIENT_TERM_PLURAL_CAP,
@@ -11,6 +11,7 @@ import RadioGroup from "../commonComponents/RadioGroup";
 import Checkboxes from "../commonComponents/Checkboxes";
 import { getPatientById } from "./patientSelectors";
 import { useDispatch, useSelector } from "react-redux";
+import { Prompt } from "react-router-dom";
 import { updatePatient } from "./state/patientActions";
 import moment from "moment";
 import { getTestResultById } from "../testResults/testResultsSelector";
@@ -29,13 +30,11 @@ const Fieldset = (props) => (
 
 const EditPatient = (props) => {
   const dispatch = useDispatch();
+  const [formChanged, setFormChanged] = useState(false);
   const { patientId, isNew } = props;
   const foundPatient = useSelector(getPatientById(patientId));
-  //TODO: work out edge cases
-  const patient = foundPatient || { patientId };
+  const [patient, setPatient] = useState(foundPatient || { patientId });
   const onChange = (e) => {
-    //TODO let reducer update one thang
-    const newPatient = { ...patient, patientId };
     let value = e.target.value;
     if (e.target.type === "checkbox") {
       value = {
@@ -43,7 +42,12 @@ const EditPatient = (props) => {
         [e.target.value]: e.target.checked,
       };
     }
-    dispatch(updatePatient({ ...newPatient, [e.target.name]: value }));
+    setFormChanged(true);
+    setPatient({ ...patient, [e.target.name]: value });
+  };
+  const savePatientData = () => {
+    setFormChanged(false);
+    dispatch(updatePatient(patient));
   };
   const results = useSelector(getTestResultById(patientId));
   const fullName = displayFullName(
@@ -54,6 +58,12 @@ const EditPatient = (props) => {
   //TODO: when to save initial data? What if name isn't filled? required fields?
   return (
     <main className="prime-edit-patient prime-home">
+      <Prompt
+        when={formChanged}
+        message={(location) =>
+          "\nYour changes are not yet saved!\n\nClick OK discard changes, Cancel to continue editing."
+        }
+      />
       <Breadcrumbs
         crumbs={[
           { link: "../patients", text: PATIENT_TERM_PLURAL_CAP },
@@ -64,7 +74,10 @@ const EditPatient = (props) => {
       />
       <div className="prime-edit-patient-heading">
         <h2>{isNew ? `Create New ${PATIENT_TERM_CAP}` : fullName}</h2>
-        <button className="usa-button prime-save-patient-changes">
+        <button
+          className="usa-button prime-save-patient-changes"
+          onClick={savePatientData}
+        >
           Save Changes
         </button>
       </div>

--- a/frontend/src/app/patients/EditPatient.jsx
+++ b/frontend/src/app/patients/EditPatient.jsx
@@ -315,6 +315,16 @@ const EditPatient = (props) => {
           </table>
         )}
       </Fieldset>
+      <div className="prime-edit-patient-heading">
+        <div></div>
+        <button
+          className="usa-button prime-save-patient-changes"
+          disabled={!formChanged}
+          onClick={savePatientData}
+        >
+          Save Changes
+        </button>
+      </div>
     </main>
   );
 };

--- a/frontend/src/app/patients/EditPatient.jsx
+++ b/frontend/src/app/patients/EditPatient.jsx
@@ -76,6 +76,7 @@ const EditPatient = (props) => {
         <h2>{isNew ? `Create New ${PATIENT_TERM_CAP}` : fullName}</h2>
         <button
           className="usa-button prime-save-patient-changes"
+          disabled={!formChanged}
           onClick={savePatientData}
         >
           Save Changes


### PR DESCRIPTION
Previously, edits to patients took effect immediately. Now, they are only saved if the user clicks the "Save Changes" button. If they try to go elsewhere without saving it pops up a modal. The modal isn't pretty but there was no design or spec for how this was to work so I just put something in to prevent data loss.