### PR TITLE
Disentangled conflicting bean profiles.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
@@ -8,17 +8,19 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 /**
- * Created by nickrobison on 11/16/20
+ * Stub no-op configuration for development and test environments.
  */
-@Profile("dev") // Configuration is only active in the dev profile
+@Profile(DevSecurityConfiguration.PROFILE)
 @Configuration
 public class DevSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(DevSecurityConfiguration.class);
 
+    public static final String PROFILE = "no-security";
+
     @Override
     public void configure(WebSecurity web) {
-        logger.warn("SECURITY DISABLED IN DEV PROFILE");
+        logger.warn("SECURITY DISABLED BY {} PROFILE", PROFILE);
         web
                 .ignoring()
                 .antMatchers("/**");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpServletResponse;
  * Created by nickrobison on 11/13/20
  */
 @Configuration
-@Profile("!dev") // Configuration should be active in every profile EXCEPT dev
+@Profile("!" + DevSecurityConfiguration.PROFILE) // Activate this profile to disable security
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 

--- a/backend/src/main/resources/application-cloud.yaml
+++ b/backend/src/main/resources/application-cloud.yaml
@@ -1,0 +1,1 @@
+spring.profiles.include: no-security

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,4 +1,5 @@
 spring:
+  profiles.include: no-security
   liquibase:
     user: simple_report_migrations
     password: migrations456

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -21,6 +21,6 @@ graphql:
 okta:
   oauth2:
     issuer: https://prime-eval.okta.com/oauth2/default
-    client-id: ${clientID}
-    client-secret: ${clientSecret}
+    client-id: ${clientID:FAKE}
+    client-secret: ${clientSecret:FAKE}
 


### PR DESCRIPTION
Made the security-disabling feature into its own profile, and included it in the "dev" and "cloud" profiles so that it is used in local dev and in cloud.gov deploys, but other local dev settings are not.

Also added fallback placeholders for the Okta OAuth2 client ID and secret, so that failure to supply them does not crash the app.