### PR TITLE
Persist API user and Ask-On-Entry questions

### DIFF
--- a/backend/db-setup/nuke-db.sh
+++ b/backend/db-setup/nuke-db.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 here=$(dirname $BASH_SOURCE)
 export PGPASSFILE=${here}/.pgpass
+chmod 0600 $PGPASSFILE # git always botches this up
 psql -h localhost -p ${SR_DB_PORT:-5432} simple_report -U postgres -f ${here}/reset-db.sql

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/User.java
@@ -1,17 +1,18 @@
 package gov.cdc.usds.simplereport.api.model;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
 
 import java.util.UUID;
 
 public class User {
 
 	private String id;
-	private Organization organization;
+	private Person person;
 
-	public User(Organization organization) {
+	public User(UUID id, Person person) {
 		super();
-		this.id = UUID.randomUUID().toString();
-		this.organization = organization;
+		this.id = id.toString();
+		this.person = person;
 	}
 
 	public String getId() {
@@ -19,6 +20,22 @@ public class User {
 	}
 
 	public Organization getOrganization() {
-		return organization;
+		return person.getOrganization();
+	}
+
+	public String getFirstName() {
+		return person.getFirstName();
+	}
+
+	public String getMiddleName() {
+		return person.getMiddleName();
+	}
+
+	public String getLastName() {
+		return person.getLastName();
+	}
+
+	public String getSuffix() {
+		return person.getSuffix();
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -1,6 +1,9 @@
 package gov.cdc.usds.simplereport.api.organization;
 
+import gov.cdc.usds.simplereport.api.model.User;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.springframework.stereotype.Component;
@@ -11,13 +14,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrganizationResolver implements GraphQLQueryResolver  {
 
-    private final OrganizationService _os;
+    private ApiUserService _userService;
 
-    public OrganizationResolver(OrganizationService os) {
-        _os = os;
+    public OrganizationResolver(OrganizationService os, ApiUserService users) {
+        _userService = users;
     }
 
     public Organization getOrganization() {
-        return _os.getCurrentOrganization();
+        return _userService.getCurrentUser().getPerson().getOrganization();
     }
+
+    public User getWhoami() {
+		ApiUser currentUser = _userService.getCurrentUser();
+		return new User(currentUser.getInternalId(), currentUser.getPerson());
+	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -3,11 +3,11 @@ package gov.cdc.usds.simplereport.api.queue;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.service.PersonService; 
 import gov.cdc.usds.simplereport.service.TestOrderService; 
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import org.springframework.stereotype.Component;
-import gov.cdc.usds.simplereport.db.model.TestOrder;
 
 import graphql.kickstart.tools.GraphQLMutationResolver;
 
@@ -29,7 +29,7 @@ public class QueueMutationResolver implements GraphQLMutationResolver  {
     public void addTestResult(String deviceID, String result, String patientID) {
       _tos.addTestResult(
         deviceID,
-        TestOrder.TestResult.valueOf(result),
+        TestResult.valueOf(result),
         patientID
       );
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -1,0 +1,56 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+import org.hibernate.annotations.NaturalId;
+
+/**
+ * The bare minimum required to link an authenticated identity to actions and data
+ * elsewhere in the schema.
+ */
+@Entity
+public class ApiUser extends AuditedEntity {
+
+	@Column(nullable = false)
+	@NaturalId
+	private String loginEmail;
+	@OneToOne(optional = false)
+	@JoinColumn(name="person_id")
+	private Person person;
+	private Date lastSeen;
+
+	public ApiUser(String email, Person attachePerson) {
+		loginEmail = email;
+		person = attachePerson;
+		lastSeen = new Date();
+	}
+
+	public String getLoginEmail() {
+		return loginEmail;
+	}
+
+	public void setLoginEmail(String loginEmail) {
+		this.loginEmail = loginEmail;
+	}
+
+	public Person getPerson() {
+		return person;
+	}
+
+	public void setPerson(Person person) {
+		this.person = person;
+	}
+
+	public Date getLastSeen() {
+		return lastSeen;
+	}
+
+	public void updateLastSeen() {
+		lastSeen = new Date();
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.NaturalId;
 
 /**
@@ -14,15 +15,18 @@ import org.hibernate.annotations.NaturalId;
  * elsewhere in the schema.
  */
 @Entity
+@DynamicUpdate
 public class ApiUser extends AuditedEntity {
 
-	@Column(nullable = false)
+	@Column(nullable = false, updatable = false)
 	@NaturalId
 	private String loginEmail;
 	@OneToOne(optional = false)
 	@JoinColumn(name="person_id")
 	private Person person;
 	private Date lastSeen;
+
+	protected ApiUser() { /* for hibernate */ }
 
 	public ApiUser(String email, Person attachePerson) {
 		loginEmail = email;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientAnswers.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PatientAnswers.java
@@ -1,0 +1,26 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import org.hibernate.annotations.Type;
+
+import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
+
+@Entity
+public class PatientAnswers extends AuditedEntity {
+
+	@Column
+	@Type(type = "jsonb")
+	private AskOnEntrySurvey askOnEntry;
+
+	protected PatientAnswers() { /* for hibernate */}
+
+	public PatientAnswers(AskOnEntrySurvey ask_on_entry) {
+		this.askOnEntry = ask_on_entry;
+	}
+
+	public AskOnEntrySurvey getSurvey() {
+		return askOnEntry;
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -25,7 +25,7 @@ public class Person extends EternalEntity {
 	private String lastName;
 	@Column
 	private String suffix;
-	@Column(nullable = false)
+	@Column
 	private LocalDate birthDate;
 	@Embedded
 	private StreetAddress address;
@@ -51,6 +51,24 @@ public class Person extends EternalEntity {
 	@OneToMany()
 	@JoinColumn(name = "patient_id")
 	private List<TestOrder> testOrders;
+
+	protected Person() { /* for hibernate */ }
+
+	public Person(String firstName, String middleName, String lastName, String suffix, Organization org) {
+		this.organization = org;
+		this.firstName = firstName;
+		this.middleName = middleName;
+		this.lastName = lastName;
+		this.suffix = suffix;
+	}
+
+	public String getTypeOfHealthcareProfessional() {
+		return typeOfHealthcareProfessional;
+	}
+
+	public List<TestOrder> getTestOrders() {
+		return testOrders;
+	}
 
 	public Person(
 		Organization organization,
@@ -129,6 +147,9 @@ public class Person extends EternalEntity {
 	}
 	public String getLastName() {
 		return lastName;
+	}
+	public String getSuffix() {
+		return suffix;
 	}
 	public LocalDate getBirthDate() {
 		return birthDate;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -10,16 +10,11 @@ import java.util.Date;
 
 import org.hibernate.annotations.Type;
 
+import gov.cdc.usds.simplereport.db.model.auxiliary.OrderStatus;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+
 @Entity
 public class TestOrder extends AuditedEntity {
-
-	public enum OrderStatus {
-		PENDING, COMPLETED, CANCELED;
-	}
-
-	public enum TestResult {
-		POSITIVE, NEGATIVE, UNDETERMINED;
-	}
 
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "patient_id")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/AskOnEntrySurvey.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/AskOnEntrySurvey.java
@@ -1,0 +1,98 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A representation of the questions we ask on test entry, somewhat but not excessively
+ * flexibly arranged to be stored and retrieved as a JSON object.
+ */
+public class AskOnEntrySurvey {
+
+	private OptionalBoolean pregnancy;
+	private Map<String, Boolean> symptoms;
+	private Boolean noSymptoms;
+	private LocalDate symptomOnsetDate;
+	private Boolean firstTest;
+	private LocalDate priorTestDate;
+	private String /* should be an enum */ priorTestType;
+	private TestResult priorTestResult;
+
+	public AskOnEntrySurvey(OptionalBoolean pregnancy, Map<String, Boolean> symptoms, Boolean noSymptoms,
+			LocalDate symptomOnsetDate, Boolean firstTest, LocalDate priorTestDate, String priorTestType,
+			TestResult priorTestResult) {
+		this.pregnancy = pregnancy;
+		this.symptoms = new HashMap<>(symptoms);
+		this.noSymptoms = noSymptoms;
+		this.symptomOnsetDate = symptomOnsetDate;
+		this.firstTest = firstTest;
+		this.priorTestDate = priorTestDate;
+		this.priorTestType = priorTestType;
+		this.priorTestResult = priorTestResult;
+	}
+
+	public OptionalBoolean getPregnancy() {
+		return pregnancy;
+	}
+
+	public void setPregnancy(OptionalBoolean pregnancy) {
+		this.pregnancy = pregnancy;
+	}
+
+	public Map<String, Boolean> getSymptoms() {
+		return symptoms;
+	}
+
+	public void setSymptoms(Map<String, Boolean> symptoms) {
+		this.symptoms = symptoms;
+	}
+
+	public Boolean getNoSymptoms() {
+		return noSymptoms;
+	}
+
+	public void setNoSymptoms(Boolean noSymptoms) {
+		this.noSymptoms = noSymptoms;
+	}
+
+	public LocalDate getSymptomOnsetDate() {
+		return symptomOnsetDate;
+	}
+
+	public void setSymptomOnsetDate(LocalDate symptomOnsetDate) {
+		this.symptomOnsetDate = symptomOnsetDate;
+	}
+
+	public Boolean getFirstTest() {
+		return firstTest;
+	}
+
+	public void setFirstTest(Boolean firstTest) {
+		this.firstTest = firstTest;
+	}
+
+	public LocalDate getPriorTestDate() {
+		return priorTestDate;
+	}
+
+	public void setPriorTestDate(LocalDate priorTestDate) {
+		this.priorTestDate = priorTestDate;
+	}
+
+	public String getPriorTestType() {
+		return priorTestType;
+	}
+
+	public void setPriorTestType(String priorTestType) {
+		this.priorTestType = priorTestType;
+	}
+
+	public TestResult getPriorTestResult() {
+		return priorTestResult;
+	}
+
+	public void setPriorTestResult(TestResult priorTestResult) {
+		this.priorTestResult = priorTestResult;
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/OptionalBoolean.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/OptionalBoolean.java
@@ -1,0 +1,5 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+public enum OptionalBoolean {
+	YES, NO, WOULD_NOT_SPECIFY;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/OrderStatus.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/OrderStatus.java
@@ -1,0 +1,5 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+public enum OrderStatus {
+	PENDING, COMPLETED, CANCELED;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/TestResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/auxiliary/TestResult.java
@@ -1,0 +1,5 @@
+package gov.cdc.usds.simplereport.db.model.auxiliary;
+
+public enum TestResult {
+	POSITIVE, NEGATIVE, UNDETERMINED;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/package-info.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/package-info.java
@@ -17,6 +17,10 @@
 })
 @TypeDefs({
 	@TypeDef(
+		name = "jsonb",
+		typeClass=JsonBinaryType.class
+	),
+	@TypeDef(
 		name = "list-array",
 		typeClass = ListArrayType.class
 	),
@@ -35,3 +39,4 @@ import org.hibernate.annotations.TypeDefs;
 
 import com.vladmihalcea.hibernate.type.array.ListArrayType;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
@@ -1,0 +1,11 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+
+public interface ApiUserRepository extends CrudRepository<ApiUser, UUID> {
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
@@ -1,11 +1,23 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.repository.CrudRepository;
 
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 
 public interface ApiUserRepository extends CrudRepository<ApiUser, UUID> {
 
+	@EntityGraph(
+		type =  EntityGraphType.LOAD,
+		attributePaths = {
+			"person.organization.orderingProvider",
+			"person.organization.defaultDeviceType",
+			"person.organization.configuredDevices",
+		}
+	)
+	public Optional<ApiUser> findByLoginEmail(String email);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeletableEntityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/DeletableEntityRepository.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import gov.cdc.usds.simplereport.db.model.AuditedEntity;
+
+@NoRepositoryBean
+public interface DeletableEntityRepository<T extends AuditedEntity> extends CrudRepository<T, UUID> {
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientAnswersRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PatientAnswersRepository.java
@@ -1,0 +1,7 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import gov.cdc.usds.simplereport.db.model.PatientAnswers;
+
+public interface PatientAnswersRepository extends DeletableEntityRepository<PatientAnswers> {
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -1,0 +1,44 @@
+package gov.cdc.usds.simplereport.service;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
+import gov.cdc.usds.simplereport.db.repository.PersonRepository;
+
+@Service
+@Transactional
+public class ApiUserService {
+
+	private PersonRepository _personRepo;
+	private ApiUserRepository _apiUserRepo;
+	private OrganizationService _orgService;
+
+	public static final String FAKE_USER_EMAIL = "bob@example.com";
+	
+	public ApiUserService(PersonRepository personRepo, ApiUserRepository apiUserRepo, OrganizationService orgService) {
+		_personRepo = personRepo;
+		_apiUserRepo = apiUserRepo;
+		_orgService = orgService;
+	}
+
+	public ApiUser getCurrentUser() {
+		Optional<ApiUser> found = _apiUserRepo.findByLoginEmail(FAKE_USER_EMAIL);
+		if (found.isPresent()) {
+			ApiUser user = found.get();
+			user.updateLastSeen();
+			return _apiUserRepo.save(user);
+		} else {
+			Organization org = _orgService.getCurrentOrganization();
+			Person authPerson = _personRepo.save(new Person("Bobbity", "Bob", "Bobberoo", null, org));
+			return _apiUserRepo.save(new ApiUser(FAKE_USER_EMAIL, authPerson));
+		}
+	}
+	
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 
@@ -32,7 +33,7 @@ public class TestOrderService {
 		return _repo.fetchPastResultsForOrganization(_os.getCurrentOrganization());
   }
 
-  public void addTestResult(String deviceID, TestOrder.TestResult result, String patientId) {
+  public void addTestResult(String deviceID, TestResult result, String patientId) {
     TestOrder order = _repo.fetchQueueItemByIDForOrganization(_os.getCurrentOrganization(), patientId);
     order.setResult(result);
     // TODO set device

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -344,3 +344,13 @@ databaseChangeLog:
                   name: result
                   remarks: The result of the test, once it has been given.
                   type: ${database.defaultSchemaName}.TEST_RESULT
+        - createTable:
+            tableName: patient_answers
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *updated_at_column
+              - column:
+                  name: ask_on_entry
+                  type: jsonb
+                  remarks: The questions asked at order entry or at test time.

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -56,6 +56,28 @@ databaseChangeLog:
       comment: The database schema required for the initial prototype deployment of the Simple Report API.
       changes:
         - createTable:
+            tableName: api_user
+            remarks: Any user who authenticates to the API to take actions using it.
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *updated_at_column
+              - column:
+                  name: login_email
+                  type: *string
+                  remarks: The e-mail of the logged-in user, assuming that is our unique ID for users.
+                  constraints:
+                    unique: true
+                    nullable: false
+              - column:
+                  name: person_id
+                  type: *idtype
+                  remarks: A foreign key to the Person table, where we can find any other details we know about this user.
+                  constraints:
+                    unique: true
+                    nullable: false
+                    # what no foreign key? Right, that table doesn't exist yet.
+        - createTable:
             tableName: device_type
             remarks: Testing devices that may be present.
             columns:
@@ -182,7 +204,7 @@ databaseChangeLog:
                     foreignKeyName: fk__facility_device_type__device_type
                     references: device_type
         - createTable:
-            tableName: person # this is kind of fascinating -- is a user also a person? Probably so, actually?
+            tableName: person
             remarks: The personal information we store about users and patients
             columns:
               - column: *pk_column
@@ -277,6 +299,12 @@ databaseChangeLog:
                   name: resident_congregate_setting
                   remarks: Does the person live in a congregate setting?
                   type: boolean
+        - addForeignKeyConstraint: # have to add this after the fact because of the (eventual) circular relationship
+            constraintName: fk__api_user__person
+            baseTableName: api_user
+            baseColumnNames: person_id
+            referencedTableName: person
+            referencedColumnNames: internal_id
         - createTable:
             tableName: test_order
             remarks: Test orders, whether pending, completed or canceled.

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -264,7 +264,7 @@ databaseChangeLog:
                   remarks: The person's date of birth.
                   type: DATE
                   constraints:
-                    nullable: false
+                    nullable: true
               - column:
                   name: street
                   remarks: The street portion of the person's address.

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -77,6 +77,12 @@ databaseChangeLog:
                     unique: true
                     nullable: false
                     # what no foreign key? Right, that table doesn't exist yet.
+              - column:
+                  name: last_seen
+                  type: DATETIME
+                  remarks: The last time this user connected to the API.
+                  constraints:
+                    nullable: false
         - createTable:
             tableName: device_type
             remarks: Testing devices that may be present.

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -62,13 +62,23 @@ type TestOrder {
   result: String
   dateTested: String
 }
+type User {
+  id: ID
+  firstName: String
+  middleName: String
+  lastName: String
+  suffix: String
+  organization: Organization
+ }
+
 type Query {
   deviceType: [DeviceType]
   patients: [Patient]
-  patient(id: String): Patient
+  patient(id: String!): Patient
   organization: Organization
   queue: [TestOrder]
   testResults: [TestOrder]
+  whoami: User!
 }
 type Mutation {
   updateOrganization(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -12,7 +12,7 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
-import gov.cdc.usds.simplereport.db.model.TestOrder.TestResult;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 public class TestOrderRepositoryTest extends BaseRepositoryTest {
 


### PR DESCRIPTION
Store a permanent record when somebody logs in, for future reference.

Also expose that information through graphql, for current reference.