### PR TITLE
Persist test events

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
@@ -9,6 +9,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
  */
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@DynamicUpdate
 public abstract class AuditedEntity {
 
 	@Column(updatable = false, nullable = false)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/EternalEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/EternalEntity.java
@@ -3,6 +3,8 @@ package gov.cdc.usds.simplereport.db.model;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Intermediate base class for entities that should be tagged as "deleted" in
  * the database rather than actually being deleted.
@@ -16,6 +18,7 @@ public class EternalEntity extends AuditedEntity {
 	/**
 	 * Is this entity soft-deleted? HINT: you should almost never need to ask.
 	 */
+	@JsonIgnore // this is an artifact of serializing the data at test time, but also seems... correct?
 	public boolean isDeleted() {
 		return isDeleted;
 	}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -10,7 +10,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
@@ -45,8 +44,7 @@ public class Person extends EternalEntity {
 	@Column(nullable = false)
 	private boolean employedInHealthcare;
 	@Column
-	@JsonProperty(value = "role")
-	private String typeOfHealthcareProfessional;
+	private String role;
 	@Column(nullable = false)
 	private boolean residentCongregateSetting;
 	@ManyToOne(optional = false)
@@ -66,10 +64,6 @@ public class Person extends EternalEntity {
 		this.middleName = middleName;
 		this.lastName = lastName;
 		this.suffix = suffix;
-	}
-
-	public String getTypeOfHealthcareProfessional() {
-		return typeOfHealthcareProfessional;
 	}
 
 	public List<TestOrder> getTestOrders() {
@@ -102,7 +96,7 @@ public class Person extends EternalEntity {
 		this.telephone = telephone;
 		this.address = address;
 		this.organization = organization;
-		this.typeOfHealthcareProfessional = role;
+		this.role = role;
 		this.email = email;
 		this.race = race;
 		this.ethnicity = ethnicity;
@@ -135,7 +129,7 @@ public class Person extends EternalEntity {
 		this.birthDate = birthDate;
 		this.telephone = telephone;
 		this.address = address;
-		this.typeOfHealthcareProfessional = role;
+		this.role = role;
 		this.email = email;
 		this.race = race;
 		this.ethnicity = ethnicity;
@@ -247,8 +241,7 @@ public class Person extends EternalEntity {
 		return testOrders;
 	}
 
-	@JsonIgnore
 	public String getRole() {
-		return typeOfHealthcareProfessional; // TODO this is extremely bad smelling
+		return role;
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -9,6 +9,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 
@@ -42,14 +45,17 @@ public class Person extends EternalEntity {
 	@Column(nullable = false)
 	private boolean employedInHealthcare;
 	@Column
+	@JsonProperty(value = "role")
 	private String typeOfHealthcareProfessional;
 	@Column(nullable = false)
 	private boolean residentCongregateSetting;
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "organization_id")
+	@JsonIgnore // don't descend this model graph when serializing for TestEvent
 	private Organization organization;
 	@OneToMany()
 	@JoinColumn(name = "patient_id")
+	@JsonIgnore // dear Lord do not attempt to serialize this
 	private List<TestOrder> testOrders;
 
 	protected Person() { /* for hibernate */ }
@@ -188,6 +194,7 @@ public class Person extends EternalEntity {
 		return organization;
 	}
 
+	@JsonIgnore
 	public String getStreet() {
 		if(address == null || address.getStreet() == null || address.getStreet().isEmpty()) {
 			return "";
@@ -195,6 +202,7 @@ public class Person extends EternalEntity {
 		return address.getStreet().get(0);
 	}
 
+	@JsonIgnore
 	public String getStreetTwo() {
 		if(address == null || address.getStreet() == null || address.getStreet().size() < 2) {
 			return "";
@@ -202,6 +210,7 @@ public class Person extends EternalEntity {
 		return address.getStreet().get(1);
 	}
 
+	@JsonIgnore
 	public String getCity() {
 		if(address == null) {
 			return "";
@@ -209,6 +218,7 @@ public class Person extends EternalEntity {
 		return address.getCity();
 	}
 
+	@JsonIgnore
 	public String getState() {
 		if(address == null) {
 			return "";
@@ -216,6 +226,7 @@ public class Person extends EternalEntity {
 		return address.getState();
 	}
 
+	@JsonIgnore
 	public String getZipCode() {
 		if(address == null) {
 			return "";
@@ -223,6 +234,7 @@ public class Person extends EternalEntity {
 		return address.getPostalCode();
 	}
 
+	@JsonIgnore
 	public String getCounty() {
 		if(address == null) {
 			return "";
@@ -230,11 +242,13 @@ public class Person extends EternalEntity {
 		return address.getCounty();
 	}
 
+	@JsonIgnore
 	public List<TestOrder> getTestResults() {
 		return testOrders;
 	}
 
+	@JsonIgnore
 	public String getRole() {
-		return typeOfHealthcareProfessional;
+		return typeOfHealthcareProfessional; // TODO this is extremely bad smelling
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -20,6 +20,12 @@ public class TestEvent extends AuditedEntity {
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
 	private TestResult result;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "patient_id")
+	private Person patient;
 	@ManyToOne
 	@JoinColumn(name = "device_type_id")
 	private DeviceType deviceType;
@@ -32,11 +38,14 @@ public class TestEvent extends AuditedEntity {
 
 	public TestEvent() {}
 
-	public TestEvent(TestResult result, DeviceType deviceType, Person patientData, Provider providerData) {
+	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Organization org) {
 		this.result = result;
 		this.deviceType = deviceType;
-		this.patientData = patientData;
-		this.providerData = providerData;
+		// store a link, and *also* store the object as JSON
+		this.patient = patient;
+		this.patientData = patient;
+		this.organization = org;
+		this.providerData = org.getOrderingProvider();
 	}
 
 	public TestResult getResult() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -1,0 +1,57 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Type;
+
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+
+@Entity
+@Immutable
+public class TestEvent extends AuditedEntity {
+
+	@Column
+	@Type(type = "pg_enum")
+	@Enumerated(EnumType.STRING)
+	private TestResult result;
+	@ManyToOne
+	@JoinColumn(name = "device_type_id")
+	private DeviceType deviceType;
+	@Column
+	@Type(type = "jsonb")
+	private Person patientData;
+	@Column
+	@Type(type = "jsonb")
+	private Provider providerData; 
+
+	public TestEvent() {}
+
+	public TestEvent(TestResult result, DeviceType deviceType, Person patientData, Provider providerData) {
+		this.result = result;
+		this.deviceType = deviceType;
+		this.patientData = patientData;
+		this.providerData = providerData;
+	}
+
+	public TestResult getResult() {
+		return result;
+	}
+
+	public DeviceType getDeviceType() {
+		return deviceType;
+	}
+
+	public Person getPatientData() {
+		return patientData;
+	}
+
+	public Provider getProviderData() {
+		return providerData;
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -63,4 +63,12 @@ public class TestEvent extends AuditedEntity {
 	public Provider getProviderData() {
 		return providerData;
 	}
+
+	public Organization getOrganization() {
+		return organization;
+	}
+
+	public Person getPatient() {
+		return patient;
+	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -9,6 +9,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 
 import org.hibernate.annotations.Type;
 
@@ -40,6 +41,11 @@ public class TestOrder extends AuditedEntity {
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
 	private TestResult result;
+	@OneToOne(optional = true)
+	@JoinColumn(name="test_event_id")
+	private TestEvent testEvent;
+
+	protected TestOrder() { /* for hibernate */ }
 
 	public TestOrder(Person patient, Organization organization, OrderStatus orderStatus, TestResult result) {
 		this.patient = patient;
@@ -93,6 +99,13 @@ public class TestOrder extends AuditedEntity {
 
 	public void cancelOrder() {
 		orderStatus = OrderStatus.CANCELED;
+	}
+
+	public TestEvent getTestEvent() {
+		return testEvent;
+	}
+	public void setTestEvent(TestEvent testEvent) {
+		this.testEvent = testEvent;
 	}
 
 	public String getPregnancy() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -1,7 +1,14 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import java.util.List;
+
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 
 public interface TestEventRepository extends AuditedEntityRepository<TestEvent> {
 
+	public List<TestEvent> findAllByPatient(Person p);
+
+	public List<TestEvent> findAllByOrganization(Organization o);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestEventRepository.java
@@ -1,0 +1,7 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import gov.cdc.usds.simplereport.db.model.TestEvent;
+
+public interface TestEventRepository extends AuditedEntityRepository<TestEvent> {
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -1,7 +1,8 @@
 package gov.cdc.usds.simplereport.service;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -1,18 +1,18 @@
 package gov.cdc.usds.simplereport.service;
 
-import java.util.List;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import gov.cdc.usds.simplereport.db.model.TestOrder;
-import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
-import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 
 /**
  * Service for fetching the device-type reference list (<i>not</i> the device types available for a

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -298,8 +298,8 @@ databaseChangeLog:
                   remarks: Is the person employed in healthcare?
                   type: boolean
               - column:
-                  name: type_of_healthcare_professional
-                  remarks: The person's role in healthcare.
+                  name: role
+                  remarks: The person's role at the facility where they are tested (e.g. "staff", "visitor", "resident").
                   type: *string
               - column:
                   name: resident_congregate_setting

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -322,6 +322,31 @@ databaseChangeLog:
                   type: jsonb
                   remarks: The questions asked at order entry or at test time.
         - createTable:
+            tableName: test_event
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *updated_at_column
+              - column:
+                  name: device_type_id
+                  remarks: The device used to record the test result.
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__test_event__device_type
+                    references: device_type
+              - column:
+                  name: patient_data
+                  type: jsonb
+                  remarks: The patient's demographics and address at the time the test was administered.
+              - column:
+                  name: provider_data
+                  type: jsonb
+                  remarks: The name and contact of the provider who ordered the test.
+              - column:
+                  name: result
+                  remarks: The result of the test, once it has been given.
+                  type: ${database.defaultSchemaName}.TEST_RESULT
+        - createTable:
             tableName: test_order
             remarks: Test orders, whether pending, completed or canceled.
             columns:
@@ -342,21 +367,21 @@ databaseChangeLog:
                   type: *idtype
                   constraints:
                     nullable: false
-                    foreignKeyName: fk__person__organization
+                    foreignKeyName: fk__test_order__organization
                     references: organization
               - column:
                   name: patient_answers_id
                   remarks: The questions asked at order entry or at test time.
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__patient_answers
+                    foreignKeyName: fk__test_order__patient_answers
                     references: patient_answers
               - column:
                   name: device_type_id
                   remarks: The device used to record the test result
                   type: *idtype
                   constraints:
-                    foreignKeyName: fk__device_type
+                    foreignKeyName: fk__test_order__device_type
                     references: device_type
               - column:
                   name: date_tested
@@ -374,3 +399,13 @@ databaseChangeLog:
                   name: result
                   remarks: The result of the test, once it has been given.
                   type: ${database.defaultSchemaName}.TEST_RESULT
+              - column:
+                  name: test_event_id
+                  type: *idtype
+                  remarks: Data saved at the time the test is marked completed.
+                  constraints:
+                    nullable: true
+                    unique: true
+                    foreignKeyName: fk__test_order__test_event
+                    references: test_event
+                    uniqueKeyName: uk__test_order__test_event

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -328,6 +328,22 @@ databaseChangeLog:
               - column: *created_at_column
               - column: *updated_at_column
               - column:
+                  name: patient_id
+                  remarks: The person who is being given the test.
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__test_event__patient__person
+                    references: person
+              - column:
+                  name: organization_id
+                  remarks: Foreign key to the facility/organization responsible for entering this person's information.
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__test_event__organization
+                    references: organization
+              - column:
                   name: device_type_id
                   remarks: The device used to record the test result.
                   type: *idtype

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiSmokeTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ApiSmokeTest.java
@@ -19,6 +19,7 @@ import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.test_util.DbTruncator;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev")
+@SuppressWarnings("checkstyle:MagicNumber")
 public class ApiSmokeTest {
 
 	@Autowired
@@ -37,7 +38,10 @@ public class ApiSmokeTest {
 		JsonNode jsonResponse = postMultipart.readTree();
 		assertTrue(jsonResponse.get("data").get("patients").isEmpty());
 		// should do this as a mutator call, but not today
-		_personService.addPatient("BAZ", "Baz", null, "Jesek", null, LocalDate.of(2403, 12, 3), "Someplace", "Nice", "Capitol", "Escobar", "12345-6678", "(12) 2345", "visitor", "baz@dendarii.net", "Vorkosigan", null, null, "M", false, false);;
+		_personService.addPatient("BAZ", "Baz", null, "Jesek", null, 
+				LocalDate.of(2403, 12, 3),
+				"Someplace", "Nice", "Capitol", "Escobar", "12345-6678",
+				"(12) 2345", "visitor", "baz@dendarii.net", "Vorkosigan", null, null, "M", false, false);
 		postMultipart = template.postForResource("person-query");
 		assertTrue(postMultipart.isOk());
 		jsonResponse = postMultipart.readTree();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -5,11 +5,15 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @ActiveProfiles("dev")
+@Import(TestDataFactory.class)
 public abstract class BaseRepositoryTest {
 
 	@Autowired

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -1,8 +1,10 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
@@ -10,4 +12,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("dev")
 public abstract class BaseRepositoryTest {
 
+	@Autowired
+	private TestEntityManager _manager;
+
+	protected void flush() {
+		_manager.flush();
+	}
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -1,0 +1,33 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
+
+public class TestEventRepositoryTest extends BaseRepositoryTest {
+
+	@Autowired
+	private TestEventRepository _repo;
+	@Autowired
+	private TestDataFactory _dataFactory;
+
+	@Test
+	public void testFindByPatient() {
+		Organization org = _dataFactory.createValidOrg();
+		Person patient = _dataFactory.createMinimalPerson(org);
+		_repo.save(new TestEvent(TestResult.POSITIVE, org.getDefaultDeviceType(), patient, org));
+		_repo.save(new TestEvent(TestResult.UNDETERMINED, org.getDefaultDeviceType(), patient, org));
+		flush();
+		List<TestEvent> found = _repo.findAllByPatient(patient);
+		assertEquals(2, found.size());
+	}
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -50,7 +50,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 	public void testLifeCycle() {
 		Provider mccoy = _providers.save(new Provider("Doc", "NCC1701", null, "(1) (111) 2222222"));
 		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt", null, mccoy));
-		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", LocalDate.now(), null, "(123) 456-7890", "", "", "", "", "", false, false));
+		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", null, LocalDate.now(), null, "(123) 456-7890", "", "", "", "", "", false, false));
 		TestOrder order = _repo.save(new TestOrder(hoya, gtown));
 		flush();
 		TestEvent ev = _events.save(new TestEvent(TestResult.POSITIVE, null, hoya, mccoy));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
@@ -24,6 +25,8 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 	private OrganizationRepository _orgRepo;
 	@Autowired
 	private ProviderRepository _providers;
+	@Autowired
+	private TestEventRepository _events;
 
 	@Test
 	public void runChanges() {
@@ -41,7 +44,18 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		_repo.save(order);
 		assertEquals(0, _repo.fetchQueueForOrganization(gtown).size());
 		assertEquals(1, _repo.fetchPastResultsForOrganization(gtown).size());
+	}
 
-
+	@Test
+	public void testLifeCycle() {
+		Provider mccoy = _providers.save(new Provider("Doc", "NCC1701", null, "(1) (111) 2222222"));
+		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt", null, mccoy));
+		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", LocalDate.now(), null, "(123) 456-7890", "", "", "", "", "", false, false));
+		TestOrder order = _repo.save(new TestOrder(hoya, gtown));
+		flush();
+		TestEvent ev = _events.save(new TestEvent(TestResult.POSITIVE, null, hoya, mccoy));
+		order.setTestEvent(ev);
+		_repo.save(order);
+		flush();
 	}
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -53,7 +53,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", null, LocalDate.now(), null, "(123) 456-7890", "", "", "", "", "", false, false));
 		TestOrder order = _repo.save(new TestOrder(hoya, gtown));
 		flush();
-		TestEvent ev = _events.save(new TestEvent(TestResult.POSITIVE, null, hoya, mccoy));
+		TestEvent ev = _events.save(new TestEvent(TestResult.POSITIVE, null, hoya, gtown));
 		order.setTestEvent(ev);
 		_repo.save(order);
 		flush();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -20,6 +20,7 @@ import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @ActiveProfiles("dev")
+@SuppressWarnings("checkstyle:MagicNumber")
 public class PersonServiceTest {
 
 	private PersonService _service;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -1,0 +1,40 @@
+package gov.cdc.usds.simplereport.test_util;
+
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.StreetAddress;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
+import gov.cdc.usds.simplereport.db.repository.PersonRepository;
+import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
+
+@Component
+public class TestDataFactory {
+
+	@Autowired
+	private OrganizationRepository _orgRepo;
+	@Autowired
+	private PersonRepository _personRepo;
+	@Autowired
+	private ProviderRepository _providerRepo;
+	@Autowired
+	private DeviceTypeRepository _deviceRepo;
+
+	public Organization createValidOrg() {
+		DeviceType dev = _deviceRepo.save(new DeviceType("Acme SuperFine", "Acme", "SFN"));
+		StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
+		Provider doc = _providerRepo.save(new Provider("Doctor Doom", "DOOOOOOM", addy, "1-900-CALL-FOR-DOC")); 
+		return _orgRepo.save(new Organization("The Mall", "MALLRAT", dev, doc));
+	}
+
+	public Person createMinimalPerson(Organization org) {
+		return _personRepo.save(new Person("John", "Brown", "Boddie", "Jr.", org));
+	}
+}


### PR DESCRIPTION
Added a persistent model for the event of having a test administered, including its result, the device, and the patient and ordering provider details as of that moment in time.

Also cleaned up a few things that cropped up along the way.