### PR TITLE
Make React routes relative to public URL

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,8 +52,8 @@
     "eject": "react-scripts eject",
     "compile-scss": "node-sass --include-path ./src/scss --include-path ./node_modules/uswds/dist/scss --output-style compressed -o ./src/styles/ ./src/scss/App.scss",
     "watch-css": "npm run compile-scss && node-sass --include-path ./src/scss --include-path ./node_modules/uswds/dist/scss -o src/styles/ --watch --recursive src/scss/App.scss",
-    "deploy-azure-dev": "react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportdev --destination-path '/app'",
-    "deploy-azure-prod": "react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportprod --destination-path '/app'"
+    "deploy-azure-dev": "REACT_APP_BACKEND_URL=https://cdc.simplereport.org/dev/api/graphql PUBLIC_URL=/dev/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportdev --destination-path '/app'",
+    "deploy-azure-prod": "REACT_APP_BACKEND_URL=https://cdc.simplereport.org/api/graphql PUBLIC_URL=/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportprod --destination-path '/app'"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/src/app/index.jsx
+++ b/frontend/src/app/index.jsx
@@ -23,7 +23,7 @@ const App = () => {
     <div className="App">
       <div id="main-wrapper">
         <USAGovBanner />
-        <Router>
+        <Router basename={process.env.PUBLIC_URL}>
           <Header organizationId={organization.id} />
           <Switch>
             <Route path="/login" component={LoginView} />


### PR DESCRIPTION
Addresses an issue where the frontend was not loading correctly in Azure, due to the basepath being set to / rather than the relative context it requires.

Simple fix to add the PUBLIC_URL env variable to the router basename.

Also updated the deploy commands to insert the correct parameters when deploying to dev and prod.

Closes https://github.com/CDCgov/prime-central/issues/143