### PR TITLE
Change text input to date input

### DIFF
--- a/frontend/src/app/patients/PatientForm.jsx
+++ b/frontend/src/app/patients/PatientForm.jsx
@@ -257,7 +257,8 @@ const PatientForm = (props) => {
         </div>
         <div className="prime-form-line">
           <TextInput
-            label="Date of Birth (MM/dd/yyyy)"
+            type="date"
+            label="Date of Birth (mm/dd/yyyy)"
             name="birthDate"
             value={patient.birthDate}
             onChange={onChange}


### PR DESCRIPTION
Simple, quick fix to make input field an html5 date input field. We should use a 508 compliant DateInput component, but this the html5 picker is better than just a plain text input for now.

Part of issue #101