### PR TITLE
Added deploy job and manifest for a training client instance.

### DIFF
--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -1,0 +1,36 @@
+name: Deploy Training Client
+
+on:
+  workflow_dispatch: # run when somebody pushes the button (on whatever branch they choose)
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Cache npm local files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ./frontend/node_modules
+          key: npm-build-${{ hashFiles('client/package-lock.json', 'client/package.json') }}
+      - name: Node setup
+        working-directory: ./frontend
+        run: npm install
+      - name: Application build
+        working-directory: ./frontend
+        run: npm run-script build
+        env:
+            REACT_APP_BACKEND_URL: https://cdc.simplereport.org/demo/api/graphql
+      - name: Deploy
+        uses: usds/cloud-gov-cli@master
+        with:
+          org: ${{secrets.CLOUD_GOV_ORG}}
+          user: ${{secrets.SERVICE_USER}}
+          password: ${{secrets.SERVICE_PASSWORD}}
+          application: prime-data-input-training
+          manifest: frontend/manifest.yml

--- a/frontend/manifest.yml
+++ b/frontend/manifest.yml
@@ -17,3 +17,11 @@ applications:
     routes:
       - route: prime-data-input-sandbox.app.cloud.gov
       - route: simple-report-sandbox.app.cloud.gov
+  - name: prime-data-input-training
+    memory: 32M
+    pushstate: enabled
+    path: build/ # specify where the app is located. The frontend gets built and deployed alongside the backend
+    buildpacks:
+      - https://github.com/cloudfoundry/staticfile-buildpack
+    routes:
+      - route: simple-report-training.app.cloud.gov


### PR DESCRIPTION
Using the API in Azure, but the front end in cloud.gov, because sometimes that is the hack you are most confident in.

(Spinning up the API in cloud.gov is also possible, but doesn't seem necessary at this juncture.)