### PR TITLE
Bandaid fix for the duplicate-queue-entry problem.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -79,6 +79,10 @@ public class QueueMutationResolver implements GraphQLMutationResolver  {
       _tos.removePatientFromQueue(patientID);
     }
 
+    public int clearQueue() {
+      return _tos.cancelAll();
+    }
+
     public void updateTimeOfTestQuestions(
       String patientID,
       String pregnancy,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -1,12 +1,15 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 
 public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> {
@@ -24,7 +27,17 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
 	@EntityGraph(attributePaths = "patient")
 	public TestOrder fetchQueueItemByIDForOrganization(Organization org, UUID id);
 
+	@Query(BASE_ORG_QUERY + "and q.orderStatus = 'PENDING' and q.patient = :patient")
+	@EntityGraph(attributePaths = "patient")
+	public Optional<TestOrder> fetchQueueItem(Organization org, Person patient);
+
+
 	@Query(BASE_ORG_QUERY + " and q.orderStatus = 'COMPLETED' ")
 	@EntityGraph(attributePaths = "patient")
 	public List<TestOrder> fetchPastResultsForOrganization(Organization org);
+
+	@Query("update #{#entityName} q set q.orderStatus = 'CANCELED' "
+			+ "where q.organization = :org and q.orderStatus = 'PENDING'")
+	@Modifying
+	public int cancelAllPendingOrders(Organization org);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -62,9 +62,9 @@ public class TestOrderService {
     LocalDate symptomOnsetDate,
     Boolean noSymptoms
   ) {
-	// Check if there is an existing queue entry for the patient. If there is one, throw an exception.
-	// If there is more than one, we throw a different exception: handling that case "elegantly" does not
-	// seem worth extra code given that it should never happen (and will result in an exception either way)
+    // Check if there is an existing queue entry for the patient. If there is one, throw an exception.
+    // If there is more than one, we throw a different exception: handling that case "elegantly" does not
+    // seem worth extra code given that it should never happen (and will result in an exception either way)
     Optional<TestOrder> existingOrder = _repo.fetchQueueItem(_os.getCurrentOrganization(), patient);
     if (existingOrder.isPresent()) {
     	throw new IllegalArgumentException("Cannot create multiple queue entries for the same patient");

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -154,6 +154,7 @@ type Mutation {
     noSymptoms: Boolean
   ): String
   removePatientFromQueue(patientId: String!): String
+  clearQueue: Int
   updateTimeOfTestQuestions(
     patientId: String!
     pregnancy: String


### PR DESCRIPTION
Added code to clear all entries from the queue, and then to check if a new queue entry would be a duplicate. This should prevent catastrophes during training, per #128, and is the first checklist item toward fixing #151.