### PR TITLE
Pull results from db, not just cache

### DIFF
--- a/frontend/src/app/testResults/TestResultsList.jsx
+++ b/frontend/src/app/testResults/TestResultsList.jsx
@@ -27,7 +27,9 @@ const testResultQuery = gql`
 `;
 
 const TestResultsList = () => {
-  const { data, loading, error } = useQuery(testResultQuery);
+  const { data, loading, error } = useQuery(testResultQuery, {
+    fetchPolicy: "cache-and-network",
+  });
 
   if (loading) {
     return <p>Loading</p>;


### PR DESCRIPTION
This doesn't handle the case where the test queue might be updated while someone is on the page. There's a way to fix that too with polling but we need to be careful.