### PR TITLE
Added user-visible error for duplicate queue submission.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/IllegalGraphqlArgumentException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/IllegalGraphqlArgumentException.java
@@ -1,0 +1,32 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+import java.util.List;
+
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+
+/**
+ * An IllegalArgumentException that will be reported as such through the <code>errors</code> key of the
+ * graphql response.
+ */
+public class IllegalGraphqlArgumentException extends IllegalArgumentException implements GraphQLError {
+
+	private static final long serialVersionUID = 1L;
+
+	public IllegalGraphqlArgumentException(String message) {
+		super(message);
+	}
+
+	@Override // probably this could have been defaulted folks
+	public List<SourceLocation> getLocations() {
+		return null;
+	}
+
+	@Override // this can be customized, but is not discernably used in the output, so we might not bother.
+	public ErrorClassification getErrorType() {
+		return ErrorType.ValidationError;
+	}
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
@@ -67,7 +68,7 @@ public class TestOrderService {
     // seem worth extra code given that it should never happen (and will result in an exception either way)
     Optional<TestOrder> existingOrder = _repo.fetchQueueItem(_os.getCurrentOrganization(), patient);
     if (existingOrder.isPresent()) {
-    	throw new IllegalArgumentException("Cannot create multiple queue entries for the same patient");
+      throw new IllegalGraphqlArgumentException("Cannot create multiple queue entries for the same patient");
     }
     TestOrder newOrder = new TestOrder(patient, _os.getCurrentOrganization());
 


### PR DESCRIPTION
Proof-of-concept for actually telling the client what they did wrong. Can either merge this or add things to it while we're in the neighborhood.