### PR TITLE
Refactor Terraform code and create test env

### DIFF
--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -8,9 +8,14 @@ data "azurerm_resource_group" "rg" {
   name = "prime-simple-report-prod"
 }
 
+data "azurerm_key_vault" "kv" {
+  name = "simplereport"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
 data "azurerm_key_vault_secret" "simplereport-db-development-password" {
   name = "simplereport"
-  vault_uri = "https://simplereport.vault.azure.net/"
+  key_vault_id = data.azurerm_key_vault.kv.id
 }
 
 data "azurerm_log_analytics_workspace" "pdi" {
@@ -214,7 +219,7 @@ resource "azurerm_container_group" "backend" {
 
   container {
     cpu = 2
-    image = "nickrobisonusds/pdi-backend:latest"
+    image = "nickrobisonusds/sr-backend:0605f1c"
     memory = 2
     name = "pdi-backend"
     ports {
@@ -223,7 +228,7 @@ resource "azurerm_container_group" "backend" {
     }
     environment_variables = {
       "SPRING_DATASOURCE_URL": "jdbc:postgresql://${data.azurerm_postgresql_server.db.fqdn}:5432/simple_report?user=simple_report_app@${data.azurerm_postgresql_server.db.name}"
-      "SPRING_DATASOURCE_PASSWORD": ${data.azurerm_key_vault_secret.simplereport-db-development-password.value}
+      "SPRING_DATASOURCE_PASSWORD": data.azurerm_key_vault_secret.simplereport-db-development-password.value
       "SPRING_PROFILES_ACTIVE": "dev"
     }
   }

--- a/ops/global/main.tf
+++ b/ops/global/main.tf
@@ -19,7 +19,7 @@ data "azurerm_resource_group" "rg" {
 
 resource "azurerm_storage_container" "state_container" {
   name = "sr-tfstate"
-  storage_account_name = "usdssimplereportprod"
+  storage_account_name = "usdssimplereportglobal"
 
   lifecycle {
     prevent_destroy = true
@@ -28,9 +28,8 @@ resource "azurerm_storage_container" "state_container" {
 
 
 // Log analytics
-
-resource "azurerm_log_analytics_workspace" "pdi-log" {
-  name = "simple-report-log-workspace"
+resource "azurerm_log_analytics_workspace" "sr" {
+  name = "simple-report-log-workspace-global"
   location = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name
   sku = "PerGB2018"
@@ -41,11 +40,61 @@ resource "azurerm_log_analytics_workspace" "pdi-log" {
 
 // ACR
 
-resource "azurerm_container_registry" "pdi" {
+resource "azurerm_container_registry" "sr" {
   location = data.azurerm_resource_group.rg.location
   name = "simplereportacr"
   resource_group_name = data.azurerm_resource_group.rg.name
   sku = "Standard"
 
   tags = local.management_tags
+}
+
+// Key vault
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "sr" {
+  location = data.azurerm_resource_group.rg.location
+  name = "simple-report-global"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  sku_name = "standard"
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  soft_delete_enabled = true
+
+//  network_acls {
+//    bypass = "AzureServices"
+//    default_action = "Deny"
+//  }
+
+  tags = local.management_tags
+}
+
+resource "azurerm_key_vault_access_policy" "self" {
+  key_vault_id = azurerm_key_vault.sr.id
+  object_id = data.azurerm_client_config.current.object_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
+
+  key_permissions = [
+    "get",
+    "list",
+    "create",
+    "delete",
+    "recover",
+  ]
+
+  secret_permissions = [
+    "get",
+    "list",
+    "set",
+    "delete",
+    "recover",
+  ]
+
+  storage_permissions = [
+    "get",
+    "list",
+    "set",
+    "delete",
+    "recover",
+  ]
 }

--- a/ops/global/variable.tf
+++ b/ops/global/variable.tf
@@ -1,3 +1,4 @@
 variable "resource_group" {
   description = "Resource Group to deploy to"
+  default = "prime-simple-report-test"
 }

--- a/ops/services/backend/main.tf
+++ b/ops/services/backend/main.tf
@@ -1,0 +1,214 @@
+locals {
+  backend_address_pool_name = "simple-report-${var.env}-backend-beap"
+  frontend_port_name = "simple-report-${var.env}-backend-feport"
+  frontend_ip_configuration_name = "simple-report-${var.env}-backend-feip"
+  http_setting_name = "simple-report-${var.env}-backend-be-htst"
+  listener_name = "simple-report-${var.env}-backend-httplstn"
+  request_routing_rule_name = "simple-report-${var.env}-backend-rqrt"
+
+  diag_appgw_logs = [
+    "ApplicationGatewayAccessLog",
+    "ApplicationGatewayPerformanceLog",
+    "ApplicationGatewayFirewallLog",
+  ]
+  diag_appgw_metrics = [
+    "AllMetrics",
+  ]
+}
+
+
+data "azurerm_key_vault_secret" "db_password" {
+  key_vault_id = var.key_vault_id
+  name = "simple-report-${var.env}-db-password"
+}
+
+// Container network
+
+resource "azurerm_subnet" "containers" {
+  name = "simple-report-${var.env}-containers"
+  resource_group_name = var.rg_name
+  virtual_network_name = var.network_name
+  address_prefixes = [
+    "10.1.250.0/24"]
+  service_endpoints = ["Microsoft.Sql"]
+
+  delegation {
+    name = "delegation"
+    service_delegation {
+      name = "Microsoft.ContainerInstance/containerGroups"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_network_profile" "containers" {
+  location = var.rg_location
+  name = "simple-report-${var.env}-container-profile"
+  resource_group_name = var.rg_name
+  container_network_interface {
+    name = "containernic"
+    ip_configuration {
+      name = "containerip"
+      subnet_id = azurerm_subnet.containers.id
+    }
+  }
+}
+
+// Container group
+resource "azurerm_container_group" "backend" {
+  count = var.backend_scale
+  name = "simple-report-${var.env}-backend-${count.index}"
+  location = var.rg_location
+  resource_group_name = var.rg_name
+  ip_address_type = "private"
+  network_profile_id = azurerm_network_profile.containers.id
+  os_type = "linux"
+
+  container {
+    cpu = 2
+    image = var.container_id
+    memory = 2
+    name = "simple-report-backend"
+    ports {
+      port = 8080
+      protocol = "TCP"
+    }
+    secure_environment_variables = {
+      "SPRING_DATASOURCE_URL": "jdbc:postgresql://${var.db_dns_name}:5432/simple_report?user=${var.db_username}@${var.db_server_name}&password=${data.azurerm_key_vault_secret.db_password.value}&sslmode=require",
+    }
+    environment_variables = {
+      "SPRING_PROFILES_ACTIVE": "dev",
+      "SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA": "public",
+    }
+  }
+
+  diagnostics {
+    log_analytics {
+      workspace_id = var.log_workspace_id
+      workspace_key = var.log_workspace_key
+    }
+  }
+
+  tags = var.tags
+}
+
+// Connect containers to DB
+resource "azurerm_postgresql_virtual_network_rule" "inbound" {
+  name = "inbound-container-subnet"
+  resource_group_name = var.rg_name
+  server_name = var.db_server_name
+  subnet_id = azurerm_subnet.containers.id
+  ignore_missing_vnet_service_endpoint = true
+}
+
+
+// Create application gateway
+// With public IP address
+
+resource "azurerm_subnet" "default" {
+  name = "simple-report-${var.env}-frontend"
+  resource_group_name = var.rg_name
+  virtual_network_name = var.network_name
+  address_prefixes = [
+    "10.1.251.0/24"]
+}
+
+resource "azurerm_public_ip" "backend" {
+  name = "backend-pip"
+  resource_group_name = var.rg_name
+  location = var.rg_location
+  allocation_method = "Dynamic"
+
+  tags = var.tags
+}
+
+// Yes, this probably will take ~20 minutes to deploy and ~5 minutes to change.
+resource "azurerm_application_gateway" "backend" {
+  name = "backend-appgateway"
+  resource_group_name = var.rg_name
+  location = var.rg_location
+
+  sku {
+    name = "Standard_Small"
+    tier = "Standard"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name = "${var.env}-backend-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.default.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.backend.id
+  }
+
+  backend_address_pool {
+    name = local.backend_address_pool_name
+    ip_addresses = azurerm_container_group.backend.*.ip_address
+  }
+
+  backend_http_settings {
+    name = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port = 8080
+    protocol = "Http"
+    request_timeout = 60
+  }
+
+  http_listener {
+    name = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name = local.frontend_port_name
+    protocol = "Http"
+  }
+
+  request_routing_rule {
+    name = local.request_routing_rule_name
+    rule_type = "Basic"
+    http_listener_name = local.listener_name
+    backend_address_pool_name = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+  }
+
+  depends_on = [
+    azurerm_public_ip.backend]
+
+  tags = var.tags
+}
+
+// Gateway analytics
+
+resource "azurerm_monitor_diagnostic_setting" "backend-awg" {
+  name = "backend-${var.env}-gateway-diag"
+  target_resource_id = azurerm_application_gateway.backend.id
+  log_analytics_workspace_id = var.log_workspace_uri
+  dynamic "log" {
+    for_each = local.diag_appgw_logs
+    content {
+      category = log.value
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+
+  dynamic "metric" {
+    for_each = local.diag_appgw_metrics
+    content {
+      category = metric.value
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+}

--- a/ops/services/backend/variables.tf
+++ b/ops/services/backend/variables.tf
@@ -1,0 +1,75 @@
+variable "env" {
+  description = "Environment to deploy into"
+  type = string
+}
+
+variable "rg_name" {
+  description = "Name of resource group to deploy into"
+  type = string
+}
+
+variable "rg_location" {
+  description = "Location of resource group to deploy into"
+  type = string
+}
+
+variable "key_vault_id" {
+  description = "ID of Key Vault to fetch secret from"
+  type = string
+}
+
+variable "log_workspace_id" {
+  description = "ID of Log Analytics Workspace to send values to"
+  type = string
+}
+
+variable "log_workspace_uri" {
+  description = "Full URI of log workspace to report to"
+  type = string
+}
+
+variable "log_workspace_key" {
+  description = "Access Key for Log Workspace"
+  type = string
+}
+
+variable "backend_scale" {
+  default = 3
+  description = "Number of backend containers to start"
+  type = number
+}
+
+variable "network_name" {
+  description = "Name of virtual network to attach to"
+  type = string
+}
+
+variable "container_id" {
+  description = "Docker container to deploy"
+  type = string
+}
+
+variable "db_dns_name" {
+  description = "FQDN of DB to connect to"
+  type = string
+}
+
+variable "db_server_name" {
+  description = "Name of DB server"
+  type = string
+}
+
+variable "db_username" {
+  description = "Username to connect to DB with"
+  type = string
+}
+
+variable "db_name" {
+  description = "Database name to connect to"
+  type = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type = map(string)
+}

--- a/ops/services/database/main.tf
+++ b/ops/services/database/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_key_vault_secret" "db_password" {
 
 resource "random_password" "random_db_password" {
   length = 30
-  special = true
+  special = false
   override_special = "!#$%&*()-_=+[]{}<>:?"
 
   # Rotated when the master_password_rotated value changes
@@ -61,16 +61,6 @@ resource "azurerm_postgresql_database" "simple_report" {
 //  start_ip_address = "0.0.0.0"
 //  end_ip_address = "0.0.0.0"
 //}
-
-resource "azurerm_postgresql_virtual_network_rule" "inbound" {
-  for_each = var.inbound_subnets
-  name = "inbound-${each.key}-subnet"
-  resource_group_name = var.rg_name
-  server_name = azurerm_postgresql_server.db.name
-  subnet_id = each.value
-  ignore_missing_vnet_service_endpoint = true
-}
-
 
 resource "azurerm_monitor_diagnostic_setting" "backend-db" {
   name = "simple-report-${var.env}-db-diag"

--- a/ops/services/database/main.tf
+++ b/ops/services/database/main.tf
@@ -1,0 +1,101 @@
+locals {
+  diag_db_logs = [
+    "PostgreSQLLogs"
+  ]
+
+  diag_db_metrics = [
+    "AllMetrics"
+  ]
+}
+
+resource "azurerm_key_vault_secret" "db_password" {
+  key_vault_id = var.key_vault_id
+  name = "simple-report-${var.env}-db-password"
+  value = random_password.random_db_password.result
+}
+
+resource "random_password" "random_db_password" {
+  length = 30
+  special = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+
+  # Rotated when the master_password_rotated value changes
+  keepers = {
+    last_rotated = var.master_password_rotated
+  }
+}
+
+resource "azurerm_postgresql_server" "db" {
+  name = "simple-report-${var.env}-db"
+  location = var.rg_location
+  resource_group_name = var.rg_name
+  sku_name = "GP_Gen5_4"
+  version = "11"
+  ssl_enforcement_enabled = false
+  administrator_login = "simple_report_app"
+  administrator_login_password = azurerm_key_vault_secret.db_password.value
+  public_network_access_enabled = true
+
+  storage_mb = 102400
+  backup_retention_days = 7
+  geo_redundant_backup_enabled = false
+  auto_grow_enabled = true
+
+  tags = var.tags
+}
+
+resource "azurerm_postgresql_database" "simple_report" {
+  charset = "UTF8"
+  collation = "English_United States.1252"
+  name = "simple_report"
+  resource_group_name = var.rg_name
+  server_name = azurerm_postgresql_server.db.name
+}
+
+# These parameters and names need to be exact: https://github.com/MicrosoftDocs/azure-docs/issues/20758
+# It looks like this only works if we enable public access. Otherwise, we need to use virtual network rules.
+//resource "azurerm_postgresql_firewall_rule" "all" {
+//  name = "AllowAllAzureIps"
+//  resource_group_name = var.rg_name
+//  server_name = azurerm_postgresql_server.db.name
+//  start_ip_address = "0.0.0.0"
+//  end_ip_address = "0.0.0.0"
+//}
+
+resource "azurerm_postgresql_virtual_network_rule" "inbound" {
+  for_each = var.inbound_subnets
+  name = "inbound-${each.key}-subnet"
+  resource_group_name = var.rg_name
+  server_name = azurerm_postgresql_server.db.name
+  subnet_id = each.value
+  ignore_missing_vnet_service_endpoint = true
+}
+
+
+resource "azurerm_monitor_diagnostic_setting" "backend-db" {
+  name = "simple-report-${var.env}-db-diag"
+  target_resource_id = azurerm_postgresql_server.db.id
+  log_analytics_workspace_id = var.log_workspace_id
+
+  dynamic "log" {
+    for_each = local.diag_db_logs
+    content {
+      category = log.value
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+
+  dynamic "metric" {
+    for_each = local.diag_db_metrics
+    content {
+      category = metric.value
+
+      retention_policy {
+        enabled = false
+      }
+    }
+  }
+}

--- a/ops/services/database/output.tf
+++ b/ops/services/database/output.tf
@@ -1,0 +1,7 @@
+output "server_name" {
+  value = azurerm_postgresql_server.db.name
+}
+
+output "server_fqdn" {
+  value = azurerm_postgresql_server.db.fqdn
+}

--- a/ops/services/database/variables.tf
+++ b/ops/services/database/variables.tf
@@ -1,0 +1,45 @@
+variable "env" {
+  type = string
+}
+
+variable "tags" {
+  description = "tags for resources created"
+  type        = map(string)
+}
+
+variable "rg_name" {
+  description = "Name of resource group to deploy into"
+  type = string
+}
+
+variable "rg_location" {
+  description = "Location of resource group to deploy into"
+  type = string
+}
+
+variable "key_vault_id" {
+  description = "ID of Key Vault to fetch secret from"
+  type = string
+}
+
+variable "log_workspace_id" {
+  description = "ID of Log Analytics Workspace to send values to"
+  type = string
+}
+
+// Note: Rotating the master password has a race condition
+// Terraform initializes the postgres module before it rotates the password
+// Terraform will succeed on the plan phase, but fail during apply
+// This is expected. Just run the deploy a second time and it will succeeed
+// To fix, the postgres module could be refactored into the main terraform state
+variable "master_password_rotated" {
+  description = "Changing this value will force the master database password to rotate. This can be any string, but a date is encourage to make tracking rotation easier."
+  type        = string
+  default     = "2020-11-23T00:00:00"
+}
+
+variable "inbound_subnets" {
+  description = "(Optional) List of subnet IDs to allow to connect to the database"
+  type = map(string)
+  default = {}
+}

--- a/ops/services/database/variables.tf
+++ b/ops/services/database/variables.tf
@@ -37,9 +37,3 @@ variable "master_password_rotated" {
   type        = string
   default     = "2020-11-23T00:00:00"
 }
-
-variable "inbound_subnets" {
-  description = "(Optional) List of subnet IDs to allow to connect to the database"
-  type = map(string)
-  default = {}
-}

--- a/ops/services/frontend/main.tf
+++ b/ops/services/frontend/main.tf
@@ -1,0 +1,15 @@
+// Frontend code
+resource "azurerm_storage_account" "frontend" {
+  account_replication_type = "GRS"
+  account_tier = "Standard"
+  account_kind = "StorageV2"
+  location = var.rg_location
+  name = "simplereport${var.env}frontend"
+  resource_group_name = var.rg_name
+  enable_https_traffic_only = true
+
+  static_website {
+    index_document = "index.html"
+  }
+  tags = var.tags
+}

--- a/ops/services/frontend/variables.tf
+++ b/ops/services/frontend/variables.tf
@@ -1,0 +1,19 @@
+variable "env" {
+  description = "Environment to deploy into"
+  type = string
+}
+
+variable "rg_name" {
+  description = "Name of resource group to deploy into"
+  type = string
+}
+
+variable "rg_location" {
+  description = "Location of resource group to deploy into"
+  type = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type = map(string)
+}

--- a/ops/test/backend.tf
+++ b/ops/test/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name = "prime-simple-report-test"
+    storage_account_name = "usdssimplereportglobal"
+    container_name = "sr-tfstate"
+    key = "test/terraform.tfstate"
+  }
+}

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -1,0 +1,62 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+  skip_provider_registration = true
+}
+locals {
+  management_tags = {
+    prime-app = "simplereport"
+    environment = "test"
+  }
+  env = "test"
+}
+
+data "azurerm_resource_group" "rg" {
+  name = "prime-simple-report-test"
+}
+
+data "azurerm_key_vault" "kv" {
+  name = "simple-report-global"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+data "azurerm_log_analytics_workspace" "law" {
+  name = "simple-report-log-workspace-global"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+data "azurerm_virtual_network" "vn" {
+  name = "simple-report-${local.env}-network"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+data "azurerm_postgresql_server" "db" {
+  name = "simple-report-${local.env}-db"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+module "backend" {
+  source = "../services/backend"
+  container_id = "nickrobisonusds/sr-backend:0605f1c"
+  db_dns_name = data.azurerm_postgresql_server.db.fqdn
+  db_server_name = data.azurerm_postgresql_server.db.name
+  db_name = "simple_report"
+  db_username = "simple_report_app"
+  env = local.env
+  key_vault_id = data.azurerm_key_vault.kv.id
+  log_workspace_id = data.azurerm_log_analytics_workspace.law.workspace_id
+  log_workspace_uri = data.azurerm_log_analytics_workspace.law.id
+  log_workspace_key = data.azurerm_log_analytics_workspace.law.primary_shared_key
+  network_name = data.azurerm_virtual_network.vn.name
+  rg_location = data.azurerm_resource_group.rg.location
+  rg_name = data.azurerm_resource_group.rg.name
+  tags = local.management_tags
+}
+
+module "frontend" {
+  source = "../services/frontend"
+  env = local.env
+  rg_location = data.azurerm_resource_group.rg.location
+  rg_name = data.azurerm_resource_group.rg.name
+  tags = local.management_tags
+}

--- a/ops/test/persistent/backend.tf
+++ b/ops/test/persistent/backend.tf
@@ -3,6 +3,6 @@ terraform {
     resource_group_name = "prime-simple-report-test"
     storage_account_name = "usdssimplereportglobal"
     container_name = "sr-tfstate"
-    key = "global/terraform.tfstate"
+    key = "test/persistent-terraform.tfstate"
   }
 }

--- a/ops/test/persistent/main.tf
+++ b/ops/test/persistent/main.tf
@@ -36,16 +36,6 @@ resource "azurerm_virtual_network" "vn" {
   tags = local.management_tags
 }
 
-resource "azurerm_subnet" "db" {
-  name = "db-subnet"
-  resource_group_name = data.azurerm_resource_group.rg.name
-  virtual_network_name = azurerm_virtual_network.vn.name
-  address_prefixes = [
-    "10.1.252.0/24"]
-  service_endpoints = ["Microsoft.Sql"]
-}
-
-
 module "db" {
   source = "../../services/database"
   env = "test"
@@ -54,7 +44,4 @@ module "db" {
   rg_location = data.azurerm_resource_group.rg.location
   rg_name = data.azurerm_resource_group.rg.name
   tags = local.management_tags
-  inbound_subnets = {
-    "db": azurerm_subnet.db.id
-  }
 }

--- a/ops/test/persistent/main.tf
+++ b/ops/test/persistent/main.tf
@@ -1,0 +1,60 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+  skip_provider_registration = true
+}
+locals {
+  management_tags = {
+    prime-app = "simplereport"
+    environment = "test"
+  }
+}
+
+data "azurerm_resource_group" "rg" {
+  name = "prime-simple-report-test"
+}
+
+data "azurerm_key_vault" "kv" {
+  name = "simple-report-global"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+data "azurerm_log_analytics_workspace" "law" {
+  name = "simple-report-log-workspace-global"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+// Create the virtual network and the persistent subnets
+
+resource "azurerm_virtual_network" "vn" {
+  name = "simple-report-test-network"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location = data.azurerm_resource_group.rg.location
+  address_space = [
+    "10.1.0.0/16"]
+
+  tags = local.management_tags
+}
+
+resource "azurerm_subnet" "db" {
+  name = "db-subnet"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vn.name
+  address_prefixes = [
+    "10.1.252.0/24"]
+  service_endpoints = ["Microsoft.Sql"]
+}
+
+
+module "db" {
+  source = "../../services/database"
+  env = "test"
+  key_vault_id = data.azurerm_key_vault.kv.id
+  log_workspace_id = data.azurerm_log_analytics_workspace.law.id
+  rg_location = data.azurerm_resource_group.rg.location
+  rg_name = data.azurerm_resource_group.rg.name
+  tags = local.management_tags
+  inbound_subnets = {
+    "db": azurerm_subnet.db.id
+  }
+}


### PR DESCRIPTION
Cleaned up the Terraform ops code to be a bit more modular.

Also deployed everything in the `prime-data-input-test` RG.
Passwords are now generated using the secure Terraform Random provider, so there's no need to manually manage them anymore.

The database is still marked as publicly available, because I'm not sure what sequence of operations I need in order to make that work with the network rules. We'll just need to manually disable for now. Eventually we can move to a private endpoint.

