### PR TITLE
Remove option to clear test data

### DIFF
--- a/frontend/src/app/commonComponents/Footer.jsx
+++ b/frontend/src/app/commonComponents/Footer.jsx
@@ -12,12 +12,6 @@ class Footer extends React.Component {
                 className="usa-footer__logo-img"
                 src={usdsLogo}
                 alt="USDS logo"
-                onClick={() => {
-                  if (window.confirm("Reset Demo Data?")) {
-                    localStorage.clear();
-                    window.location.reload(false);
-                  }
-                }}
               />
             </div>
           </div>

--- a/frontend/src/app/commonComponents/USAGovBanner.jsx
+++ b/frontend/src/app/commonComponents/USAGovBanner.jsx
@@ -76,12 +76,6 @@ export default class USAGovBanner extends React.Component {
                   className="usa-banner__header-flag"
                   src={usdsLogo}
                   alt="USDS logo"
-                  onClick={() => {
-                    if (window.confirm("Reset Demo Data?")) {
-                      localStorage.clear();
-                      window.location.reload(false);
-                    }
-                  }}
                 />
                 <img
                   className="usa-banner__header-flag"


### PR DESCRIPTION
Removed the `localStorage.clear()` from header and footer when clicking the USDS logo.