### PR TITLE
Add support for managing Okta configuration using Terraform

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -2,6 +2,28 @@
 
 ## Operations that only need to be performed once
 
+### Authentication
+
+#### Azure
+
+Azure auth is really simple and only requires installing Azure CLI and logging in.
+
+```bash
+brew install azure-cli
+az login
+```
+
+#### Okta
+
+Okta API tokens are assigned at the environment level, and not on a per user basis.
+You can create one for yourself [here](https://prime-eval-admin.okta.com/admin/access/api/tokens).
+
+```bash
+export OKTA_API_TOKEN={Okta API token}
+```
+
+### General steps
+
 The initial Terraform and environment bootstrap creates a couple of resource which are shared across the various resource groups and environments.
 
 0. Create storage account in Azure
@@ -13,7 +35,7 @@ terraform import azurerm_storage_container.state_container https://srterraform.b
 terraform apply
 ```
 
-### Operations performed once per environment
+## Operations performed once per environment
 
 First, we need to deploy the persistent services (DBs, etc) which should not be re-created on each deploy
 ```bash

--- a/ops/global/main.tf
+++ b/ops/global/main.tf
@@ -4,6 +4,11 @@ provider "azurerm" {
   skip_provider_registration = true
 }
 
+provider "okta" {
+  org_name = "prime-eval"
+  base_url = "okta.com"
+}
+
 locals {
   management_tags = {
     prime-app = "simplereport"
@@ -97,4 +102,10 @@ resource "azurerm_key_vault_access_policy" "self" {
     "delete",
     "recover",
   ]
+}
+
+// Okta configuration
+
+module "okta" {
+  source = "../services/okta-global"
 }

--- a/ops/global/versions.tf
+++ b/ops/global/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    okta = {
+      source = "oktadeveloper/okta"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -1,0 +1,22 @@
+resource "okta_app_oauth" "app" {
+  label = "simple-report-${var.env}"
+  type                       = "web"
+  grant_types                = ["authorization_code"]
+  redirect_uris              = [
+    "http://localhost:8080",
+    "http://localhost:9090",
+    "https://${var.env}.simplereport.org/app"]
+  response_types             = ["code"]
+
+  lifecycle {
+    ignore_changes = [
+    groups
+    ]
+  }
+}
+
+resource "okta_app_group_assignment" "users" {
+  count = length(var.user_groups)
+  app_id = okta_app_oauth.app.id
+  group_id = element(var.user_groups, count.index)
+}

--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -1,5 +1,5 @@
 resource "okta_app_oauth" "app" {
-  label = "simple-report-${var.env}"
+  label = "Simple Report (${var.env})"
   type                       = "web"
   grant_types                = ["authorization_code"]
   redirect_uris              = [
@@ -19,4 +19,14 @@ resource "okta_app_group_assignment" "users" {
   count = length(var.user_groups)
   app_id = okta_app_oauth.app.id
   group_id = element(var.user_groups, count.index)
+}
+
+// Link the CDC/USDS users to the application
+data "okta_group" "cdc_users" {
+  name = "Prime Team Members"
+}
+
+resource "okta_app_group_assignment" "prime_users" {
+  app_id = okta_app_oauth.app.id
+  group_id = data.okta_group.cdc_users.id
 }

--- a/ops/services/okta-app/variables.tf
+++ b/ops/services/okta-app/variables.tf
@@ -1,0 +1,16 @@
+variable "env" {
+  description = "Environment to deploy into"
+  type = string
+}
+
+variable "user_groups" {
+  description = "List of user groups to assign to the application"
+  type = list(string)
+  default = []
+}
+
+variable "admin_groups" {
+  description = "List of user groups to assign to the application as administrators"
+  type = list(string)
+  default = []
+}

--- a/ops/services/okta-app/versions.tf
+++ b/ops/services/okta-app/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    okta = {
+      source = "oktadeveloper/okta"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/ops/services/okta-global/main.tf
+++ b/ops/services/okta-global/main.tf
@@ -1,0 +1,75 @@
+// Create the required simple report scope
+
+data "okta_auth_server" "default" {
+  name = "default"
+}
+
+// We need to import and manage the pdi scope as well.
+// So we can remove it later
+
+resource "okta_auth_server_scope" "sr" {
+  auth_server_id = data.okta_auth_server.default.id
+  name = "simple_report"
+  description = "Default OAUTH scope for Simple Report application"
+  metadata_publish = "NO_CLIENTS"
+  default = false
+}
+
+// Add the required claims
+resource "okta_auth_server_claim" "sr_user" {
+  auth_server_id = data.okta_auth_server.default.id
+  claim_type = "RESOURCE"
+  name = "org"
+  value = "appuser.pdi_org"
+  scopes = [
+    okta_auth_server_scope.sr.name,
+    "pdi"]
+}
+
+resource "okta_auth_server_claim" "sr_org" {
+  auth_server_id = data.okta_auth_server.default.id
+  claim_type = "RESOURCE"
+  name = "access"
+  value = "appuser.pdi_user"
+  scopes = [
+    okta_auth_server_scope.sr.name,
+    "pdi"]
+}
+
+resource "okta_auth_server_claim" "family_name" {
+  auth_server_id = data.okta_auth_server.default.id
+  claim_type = "RESOURCE"
+  name = "family_name"
+  value = "user.lastName"
+  scopes = [
+    okta_auth_server_scope.sr.name,
+    "pdi"]
+}
+
+resource "okta_auth_server_claim" "given_name" {
+  auth_server_id = data.okta_auth_server.default.id
+  claim_type = "RESOURCE"
+  name = "given_name"
+  value = "user.firstName"
+  scopes = [
+    okta_auth_server_scope.sr.name,
+    "pdi"]
+}
+
+resource "okta_auth_server_claim" "groups" {
+  auth_server_id = data.okta_auth_server.default.id
+  claim_type = "RESOURCE"
+  name = "groups"
+  value_type = "GROUPS"
+  group_filter_type = "REGEX"
+  value = ".*"
+  scopes = [
+    okta_auth_server_scope.sr.name,
+    "pdi"]
+}
+
+// Create the CDC/USDS user groups
+resource "okta_group" "prime_users" {
+  name = "Prime Team Members"
+  description = "All Prime team members"
+}

--- a/ops/services/okta-global/versions.tf
+++ b/ops/services/okta-global/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    okta = {
+      source = "oktadeveloper/okta"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -3,6 +3,12 @@ provider "azurerm" {
   features {}
   skip_provider_registration = true
 }
+
+provider "okta" {
+  org_name = "prime-eval"
+  base_url = "okta.com"
+}
+
 locals {
   management_tags = {
     prime-app = "simplereport"
@@ -59,4 +65,11 @@ module "frontend" {
   rg_location = data.azurerm_resource_group.rg.location
   rg_name = data.azurerm_resource_group.rg.name
   tags = local.management_tags
+}
+
+
+// Okta application
+module "okta" {
+  source = "../services/okta-app"
+  env = local.env
 }

--- a/ops/test/versions.tf
+++ b/ops/test/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    okta = {
+      source = "oktadeveloper/okta"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Add the Okta terraform provider and configure things to work correctly.

Extremely simple setup for now, we can create some `global` resources, which are the auth scopes and claims that are shared across environments.

We can also create an OAuth application per environment.

Overtime, we'll need to migrate our manually created settings into TF, that will probably require removing them and re-creating them, since Okta doesn't expose all of its concepts as data blocks, so not very easy to get the appropriate IDs.