### PR TITLE
Very simple mechanism to pass error messages back to client

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SimpleTestGraphQLError.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/SimpleTestGraphQLError.java
@@ -1,0 +1,35 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import graphql.ErrorClassification;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+
+/**
+ * Very simple way of passing an error message back to the client.
+ */
+public class SimpleTestGraphQLError extends RuntimeException implements GraphQLError {
+
+  private final String message;
+
+  public SimpleTestGraphQLError(String message) {
+    super(message);
+    this.message = message;
+  }
+
+  @Override
+  public String getMessage() {
+    return this.message;
+  }
+
+  @Override
+  public List<SourceLocation> getLocations() {
+    return null;
+  }
+
+  @Override
+  public ErrorClassification getErrorType() {
+    return null;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import gov.cdc.usds.simplereport.api.model.SimpleTestGraphQLError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,7 +68,7 @@ public class TestOrderService {
     // seem worth extra code given that it should never happen (and will result in an exception either way)
     Optional<TestOrder> existingOrder = _repo.fetchQueueItem(_os.getCurrentOrganization(), patient);
     if (existingOrder.isPresent()) {
-    	throw new IllegalArgumentException("Cannot create multiple queue entries for the same patient");
+    	throw new SimpleTestGraphQLError("Cannot create multiple queue entries for the same patient");
     }
     TestOrder newOrder = new TestOrder(patient, _os.getCurrentOrganization());
 

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.jsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.jsx
@@ -137,7 +137,17 @@ const AddToQueueSearchBox = ({ refetchQueue }) => {
         showNotification(toast, alert);
         refetchQueue();
       },
-      (err) => console.error(err)
+      (err) => {
+        console.error(err, err.stack);
+        let alert = (
+          <Alert
+            type="error"
+            title="Problem saving data"
+            body={err.toString()}
+          />
+        );
+        showNotification(toast, alert);
+      }
     );
   };
 


### PR DESCRIPTION
Implement GraphQLError exception that simply saves the error message and allows GraphQL to pass it back to the client.
Added support to show error message as an alert. Right now it's only on AddToQueueSearch

Demo of it working: https://youtu.be/eDYmhswLyWA