### PR TITLE
Slightly excessive re-wiring of first-run initialization code.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -4,10 +4,14 @@ import javax.servlet.Filter;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
 
+import gov.cdc.usds.simplereport.config.InitialSetupProperties;
+
 @SpringBootApplication
+@EnableConfigurationProperties(InitialSetupProperties.class)
 public class SimpleReportApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationResolver.java
@@ -1,17 +1,14 @@
 package gov.cdc.usds.simplereport.api.organization;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
 
 import gov.cdc.usds.simplereport.api.model.User;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.ApiUserService;
+import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
-import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import graphql.kickstart.tools.GraphQLQueryResolver;
-import org.springframework.stereotype.Component;
 
 /**
  * Created by nickrobison on 11/17/20
@@ -20,35 +17,14 @@ import org.springframework.stereotype.Component;
 public class OrganizationResolver implements GraphQLQueryResolver  {
 
     private ApiUserService _userService;
-    private DeviceTypeService _deviceService;
 	private OrganizationService _organizationService;
 
-    public OrganizationResolver(OrganizationService os, ApiUserService users, DeviceTypeService devices) {
+    public OrganizationResolver(OrganizationService os, ApiUserService users, OrganizationInitializingService initer) {
         _organizationService = os;
         _userService = users;
-        _deviceService = devices;
     }
 
     public Organization getOrganization() {
-
-        List<DeviceType> currentDevices = _deviceService.fetchDeviceTypes();
-        List<String> currentDeviceNames = currentDevices.stream().map(d->d.getName()).collect(Collectors.toList());
-        String sharedLoinc = "94558-4"; // sigh
-        if (!currentDeviceNames.contains("Abbott IDNow")) {
-            _deviceService.createDeviceType("Abbott IDNow", "ID Now", "Abbott", sharedLoinc);
-        }
-        if (!currentDeviceNames.contains("Abbott BinaxNow")) {
-            _deviceService.createDeviceType("Abbott BinaxNow", "BinaxNOW COVID-10 Ag Card", "Abbott", sharedLoinc);
-        }
-        if (!currentDeviceNames.contains("Quidel Sofia 2")) {
-            _deviceService.createDeviceType("Quidel Sofia 2", "Sofia 2 SARS Antigen FIA", "Quidel", sharedLoinc);
-        }
-        if (!currentDeviceNames.contains("BD Veritor")) {
-            _deviceService.createDeviceType("BD Veritor", "BD Veritor System for Rapid Detection of SARS-CoV-2*", "Becton, Dickinson and Company (BD)", sharedLoinc);
-        }
-        if (!currentDeviceNames.contains("LumiraDX")) {
-            _deviceService.createDeviceType("LumiraDX", "LumiraDX", "LumiraDX", sharedLoinc);
-        }
         return _organizationService.getCurrentOrganization();
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -1,0 +1,76 @@
+package gov.cdc.usds.simplereport.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.StreetAddress;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+
+@ConfigurationProperties(prefix = "simple-report-initialization")
+@ConstructorBinding
+public class InitialSetupProperties {
+
+	private Organization organization;
+	private ConfigProvider provider;
+	private List<? extends ConfigDeviceType> deviceTypes;
+	private List<String> configuredDeviceTypes;
+
+	public InitialSetupProperties(ConfigOrganization organization, ConfigProvider provider,
+			List<ConfigDeviceType> deviceTypes, List<String> configuredDeviceTypes) {
+		this.organization = organization;
+		this.provider = provider;
+		this.deviceTypes = deviceTypes;
+		this.configuredDeviceTypes = configuredDeviceTypes;
+	}
+
+	public List<String> getConfiguredDeviceTypeNames() {
+		return configuredDeviceTypes;
+	}
+
+	public Organization getOrganization() {
+		return organization;
+	}
+
+	public Provider getProvider() {
+		return provider.getRealProvider();
+	}
+
+	public List<? extends DeviceType> getDeviceTypes() {
+		return deviceTypes.stream().map(ConfigDeviceType::getReal).collect(Collectors.toList());
+	}
+
+	private static final class ConfigOrganization extends Organization {
+		@ConstructorBinding
+		public ConfigOrganization(String facilityName, String externalId, String cliaNumber) {
+			super(facilityName, externalId, cliaNumber);
+		}
+	}
+	public static final class ConfigProvider extends Provider {
+		@ConstructorBinding
+		public ConfigProvider(String firstName, String middleName, String lastName, String suffix, String providerId,
+				StreetAddress address, String telephone) {
+			super(firstName, middleName, lastName, suffix, providerId, address, telephone);
+		}
+		public Provider getRealProvider() {
+			PersonName nm = getNameInfo();
+			return new Provider(nm.getFirstName(), nm.getMiddleName(), nm.getLastName(), nm.getSuffix(),
+				getProviderId(), getAddress(), getTelephone());
+		}
+	}
+
+	private static final class ConfigDeviceType extends DeviceType {
+		@ConstructorBinding
+		public ConfigDeviceType(String name, String manufacturer, String model, String loincCode) {
+			super(name, manufacturer, model, loincCode);
+		}
+		public DeviceType getReal() {
+			return new DeviceType(getName(), getManufacturer(), getModel(), getLoincCode());
+		}
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/StreetAddress.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/StreetAddress.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import org.hibernate.annotations.Type;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -42,6 +43,7 @@ public class StreetAddress {
     /**
      * Convenience constructor for situations where we have a two-line address already
      */
+    @ConstructorBinding
     public StreetAddress(String street1, String street2, String city, String state, String postalCode, String county) {
         this(null, city, state, postalCode, county);
         if (street1 != null && !street1.isEmpty()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -1,0 +1,67 @@
+package gov.cdc.usds.simplereport.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gov.cdc.usds.simplereport.config.InitialSetupProperties;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
+import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
+
+@Service
+@Transactional
+public class OrganizationInitializingService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrganizationInitializingService.class);
+
+	@Autowired
+	private InitialSetupProperties _props;
+	@Autowired
+	private OrganizationRepository _orgRepo;
+	@Autowired
+	private ProviderRepository _providerRepo;
+	@Autowired
+	private DeviceTypeRepository _deviceTypeRepo;
+
+	public void initAll() {
+		Organization emptyOrg = _props.getOrganization();
+		Optional<Organization> probe = _orgRepo.findByExternalId(emptyOrg.getExternalId());
+		if (probe.isPresent()) {
+			return; // one and done
+		}
+		Provider savedProvider = _providerRepo.save(_props.getProvider());
+		 Map<String, DeviceType> byName = _deviceTypeRepo.findAll().stream().collect(
+				Collectors.toMap(d->d.getName(), d->d));
+		for (DeviceType d : _props.getDeviceTypes()) {
+			DeviceType deviceType = byName.get(d.getName());
+			if (null == deviceType) {
+				LOG.info("Creating device {}", d.getName());
+				deviceType = _deviceTypeRepo.save(d);
+				byName.put(deviceType.getName(), deviceType);
+			}
+		}
+		List<DeviceType> configured= _props.getConfiguredDeviceTypeNames().stream()
+				.map(name->byName.get(name))
+				.collect(Collectors.toList());
+		DeviceType defaultDeviceType = configured.get(0);
+		LOG.info("Creating organization {} with {} devices configured", emptyOrg.getFacilityName(), configured.size());
+		Organization realOrg = new Organization(emptyOrg.getFacilityName(), emptyOrg.getExternalId(),
+				emptyOrg.getCliaNumber(), defaultDeviceType, savedProvider, configured);
+		_orgRepo.save(realOrg);
+	}
+
+	public String getDefaultOrganizationId() {
+		return _props.getOrganization().getExternalId();
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -11,29 +11,27 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
-import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 
 @Service
 @Transactional(readOnly=false)
 public class OrganizationService {
 
 	private OrganizationRepository _repo;
-	private ProviderRepository _providerRepo;
+	private OrganizationInitializingService _initService;
 
-	public static final String FAKE_ORG_ID = "123";
-
-	public OrganizationService(OrganizationRepository repo, ProviderRepository providers) {
+	public OrganizationService(OrganizationRepository repo,
+			OrganizationInitializingService initService) {
 		_repo = repo;
-		_providerRepo = providers;
+		_initService = initService;
 	}
 
 	public Organization getCurrentOrganization() {
-		Optional<Organization> maybe = _repo.findByExternalId(FAKE_ORG_ID);
+    	_initService.initAll();
+		Optional<Organization> maybe = _repo.findByExternalId(_initService.getDefaultOrganizationId());
 		if (maybe.isPresent()) {
 			return maybe.get();
 		} else {
-			Provider p = _providerRepo.save(new Provider("John", "H", "Watson", "Dr", "XXXXX", null, "(202) 555-4321"));
-			return _repo.save(new Organization("This Place", FAKE_ORG_ID, "11111", null, p));
+			throw new RuntimeException("Default organization not found: serious troubles");
 		}
 	}
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -8,3 +8,21 @@ spring:
       hibernate:
         show_sql: true
         default_schema: simple_report
+simple-report-initialization:
+  organization:
+    facility-name: Dis Organization
+    external-id: DIS_ORG
+    clia-number: "000111222-3"
+  provider:
+    first-name: Fred
+    last-name: Flintstone
+    provider-id: PEBBLES
+    telephone: (202) 555-1212
+    address:
+      street-1: 123 Main Street
+      city: Oz
+      state: KS
+      zip-code: "12345"
+  configured-device-types:
+    - LumiraDX
+    - Quidel Sofia 2

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -25,4 +25,25 @@ okta:
     issuer: https://hhs-prime.okta.com/oauth2/default
     client-id: ${clientID:FAKE}
     client-secret: ${clientSecret:FAKE}
-
+simple-report-initialization:
+  device-types:
+    - name: Abbott IDNow
+      manufacturer: Abbott
+      model: ID Now
+      loinc-code: "94558-4"
+    - name: Abbott BinaxNow
+      manufacturer: Abbott
+      model: BinaxNow
+      loinc-code: "94558-4"
+    - name: Quidel Sofia 2
+      manufacturer: Quidel
+      model: Sofia 2 SARS Antigen FIA
+      loinc-code: "94558-4"
+    - name: BD Veritor
+      manufacturer: Becton, Dickinson and Company (BD)
+      model: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
+      loinc-code: "94558-4"
+    - name: LumiraDX
+      manufacturer: LumiraDX
+      model: LumiraDX
+      loinc-code: "94558-4"

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -9,20 +9,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
-import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 
 public class OrganizationServiceTest extends BaseRepositoryTest {
 
 	private OrganizationService _service;
 	
-	public OrganizationServiceTest(@Autowired OrganizationRepository repo, @Autowired ProviderRepository providers) {
-		_service = new OrganizationService(repo, providers);
+	public OrganizationServiceTest(@Autowired OrganizationRepository repo, @Autowired OrganizationInitializingService initService) {
+		_service = new OrganizationService(repo, initService);
 	}
 
 	@Test
 	public void findit() {
 		Organization org = _service.getCurrentOrganization();
 		assertNotNull(org);
-		assertEquals(OrganizationService.FAKE_ORG_ID, org.getExternalId());
+		assertEquals("DIS_ORG", org.getExternalId());
 	}
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -12,15 +12,14 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
-import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 
 @SuppressWarnings("checkstyle:MagicNumber")
 public class PersonServiceTest extends BaseRepositoryTest {
 
 	private PersonService _service;
 
-	public PersonServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired ProviderRepository providerRepo, @Autowired PersonRepository repo) {
-		OrganizationService os= new OrganizationService(orgRepo, providerRepo);
+	public PersonServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
+		OrganizationService os= new OrganizationService(orgRepo, initService);
 		_service = new PersonService(os, repo);
 	}
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -21,7 +21,6 @@ import gov.cdc.usds.simplereport.db.model.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
-import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 
 /**
  * Created by nickrobison on 11/21/20
@@ -31,8 +30,8 @@ class UploadServiceTest extends BaseRepositoryTest {
     private final PersonService _ps;
     private final UploadService _service;
 
-    public UploadServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired ProviderRepository providerRepo, @Autowired PersonRepository repo) {
-        OrganizationService os = new OrganizationService(orgRepo, providerRepo);
+    public UploadServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
+        OrganizationService os = new OrganizationService(orgRepo, initService);
         this._ps = new PersonService(os, repo);
         this._service = new UploadService(_ps);
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -1,11 +1,14 @@
 package gov.cdc.usds.simplereport.test_util;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 import gov.cdc.usds.simplereport.config.AuditingConfig;
 import gov.cdc.usds.simplereport.config.DevSecurityConfiguration;
+import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.service.ApiUserService;
+import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 
 /**
@@ -13,7 +16,8 @@ import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
  * context being created. This is not annotated with a Spring stereotype because we very much
  * do not want it to be picked up automatically!
  */
-@Import({TestDataFactory.class, AuditingConfig.class, ApiUserService.class})
+@Import({TestDataFactory.class, AuditingConfig.class, ApiUserService.class, OrganizationInitializingService.class})
+@EnableConfigurationProperties(InitialSetupProperties.class)
 public class SliceTestConfiguration {
 
 	@Bean


### PR DESCRIPTION
Made organization, provider and device initialization property-driven.
Broke and fixed a great deal of code and not a few tests.

In slightly more detail:
* pick up device details, organization details, and provider information from application properties
* on org fetches, run a check for the default organization: if it's found, do nothing
* if it's not found, initialize it (and the device list) from the properties file

Everything else is just wiring.

Putting this up as a PR against the previous branch so people can see what's related to what.

Resolves #170.