### PR TITLE
Backend datetime support

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	// UI layer dependencies
 	implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:${kickstartVersion}"
 	implementation "com.graphql-java-kickstart:graphiql-spring-boot-starter:${kickstartVersion}"
+	implementation "com.zhokhov.graphql:graphql-datetime-spring-boot-starter:3.0.0"
 	implementation 'org.json:json:20201115'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
 

--- a/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -39,6 +39,10 @@ com.sun.istack:istack-commons-runtime:3.0.11
 com.sun.mail:javax.mail:1.6.1
 com.vladmihalcea:hibernate-types-52:2.10.0
 com.zaxxer:HikariCP:3.4.5
+com.zhokhov.graphql:graphql-datetime-autoconfigure-common:3.0.0
+com.zhokhov.graphql:graphql-datetime-autoconfigure:3.0.0
+com.zhokhov.graphql:graphql-datetime-spring-boot-starter:3.0.0
+com.zhokhov.graphql:graphql-java-datetime:3.0.0
 io.micrometer:micrometer-core:1.5.6
 jakarta.activation:jakarta.activation-api:1.2.2
 jakarta.annotation:jakarta.annotation-api:1.3.5

--- a/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -41,6 +41,10 @@ com.sun.istack:istack-commons-runtime:3.0.11
 com.sun.mail:javax.mail:1.6.1
 com.vladmihalcea:hibernate-types-52:2.10.0
 com.zaxxer:HikariCP:3.4.5
+com.zhokhov.graphql:graphql-datetime-autoconfigure-common:3.0.0
+com.zhokhov.graphql:graphql-datetime-autoconfigure:3.0.0
+com.zhokhov.graphql:graphql-datetime-spring-boot-starter:3.0.0
+com.zhokhov.graphql:graphql-java-datetime:3.0.0
 io.micrometer:micrometer-core:1.5.6
 jakarta.activation:jakarta.activation-api:1.2.2
 jakarta.annotation:jakarta.annotation-api:1.3.5

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestResult.java
@@ -1,0 +1,102 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import java.util.Date;
+import java.util.Map;
+import java.time.LocalDate;
+
+import org.json.JSONObject;
+
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
+
+
+public class TestResult {
+
+	private TestEvent event;
+	private AskOnEntrySurvey survey;
+
+	public TestResult(TestEvent event) {
+		super();
+		this.event = event;
+		this.survey = event.getTestOrder().getAskOnEntrySurvey().getSurvey();
+
+	}
+
+	public String getInternalId() {
+		return event.getInternalId().toString();
+	}
+
+	public Organization getOrganization() {
+		return event.getOrganization();
+	}
+
+	public Date getDateAdded() {
+		return event.getTestOrder().getDateAdded();
+	}
+
+	public String getPregnancy() {
+		return survey.getPregnancy();
+	}
+
+	public Boolean getNoSymptoms() {
+		return survey.getNoSymptoms();
+	}
+
+	public String getSymptoms() {
+		Map<String, Boolean> s = survey.getSymptoms();
+		JSONObject obj = new JSONObject();
+		for (Map.Entry<String,Boolean> entry : s.entrySet()) {
+			obj.put(entry.getKey(), entry.getValue().toString());
+		}
+		return obj.toString();
+	}
+
+	public LocalDate getSymptomOnset() {
+		return survey.getSymptomOnsetDate();
+	}
+
+
+	public Boolean getFirstTest() {
+		return survey.getFirstTest();
+	}
+
+
+	public LocalDate getPriorTestDate() {
+		return survey.getPriorTestDate();
+	}
+
+
+	public String getPriorTestType() {
+		return survey.getPriorTestType();
+	}
+
+
+	public String getPriorTestResult() {
+		return survey.getPriorTestResult() == null ? "" : survey.getPriorTestResult().toString();
+	}
+
+
+	public DeviceType getDeviceType() {
+		return event.getDeviceType();
+	}
+
+
+	public Person getPatient() {
+		return event.getPatient();
+	}
+
+
+	public String getResult() {
+		return event.getResult().toString();
+	}
+
+
+	public Date getDateTested() {
+		return event.getCreatedAt();
+	}
+
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueResolver.java
@@ -1,27 +1,32 @@
 package gov.cdc.usds.simplereport.api.queue;
 
+import java.util.List;
+import java.util.stream.Collectors;
 
-import gov.cdc.usds.simplereport.db.model.TestOrder;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import org.springframework.stereotype.Component;
-import gov.cdc.usds.simplereport.service.TestOrderService; 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
-/**
- * Created by nickrobison on 11/15/20
- */
+import gov.cdc.usds.simplereport.api.model.TestResult;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.service.TestOrderService; 
+
+
 @Component
 public class QueueResolver implements GraphQLQueryResolver {
 
-  @Autowired
-  private TestOrderService tos;
+	@Autowired
+	private TestOrderService tos;
 
-  public List<TestOrder> getQueue() {
-    return tos.getQueue();
-  }
+	public List<TestOrder> getQueue() {
+		return tos.getQueue();
+	}
 
-  public List<TestOrder> getTestResults() {
-    return tos.getTestResults();
-  }
+	public List<TestResult> getTestResults() {
+		return tos.getTestResults().stream()
+			.map(r -> new TestResult(r.getTestEvent()))
+			.collect(Collectors.toList());
+	}
 }
+
+

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -20,6 +20,10 @@ graphql:
     corsEnabled: true
   tools:
     schema-location-pattern: "**/*.graphqls"
+  datetime:
+    scalars:
+      Date:
+        format: yyyy-MM-dd'T'HH:MM:ss'Z'
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -1,4 +1,6 @@
-# Comments in GraphQL strings (such as this one) start with the hash (#) symbol.
+# java.util.Date implementation
+scalar Date
+
 type DeviceType {
   internalId: ID
   name: String
@@ -64,7 +66,7 @@ type TestOrder {
   priorTestResult: String
   deviceType: DeviceType
   result: String
-  dateTested: String
+  dateTested: Date
 }
 
 type User {

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -51,7 +51,25 @@ type Organization {
   deviceTypes: [DeviceType]
   defaultDeviceType: DeviceType
 }
+# TestResult and TestOrder should have the same properties
 type TestOrder {
+  internalId: ID
+  patient: Patient
+  organization: Organization
+  dateAdded: String
+  pregnancy: String
+  noSymptoms: Boolean
+  symptoms: String
+  symptomOnset: String
+  firstTest: Boolean
+  priorTestDate: String
+  priorTestType: String
+  priorTestResult: String
+  deviceType: DeviceType
+  result: String
+  dateTested: String
+}
+type TestResult {
   internalId: ID
   patient: Patient
   organization: Organization
@@ -84,7 +102,7 @@ type Query {
   patient(id: String!): Patient
   organization: Organization
   queue: [TestOrder]
-  testResults: [TestOrder]
+  testResults: [TestResult]
   whoami: User!
 }
 type Mutation {

--- a/frontend/src/app/patients/PatientForm.jsx
+++ b/frontend/src/app/patients/PatientForm.jsx
@@ -476,7 +476,7 @@ const PatientForm = (props) => {
             <tbody>
               {patient.testResults.map((r, i) => (
                 <tr key={i}>
-                  <td>{moment(r.dateTested).format("MMM DD YYYY")}</td>
+                  <td>{moment(r.dateTested).format("lll")}</td>
                   <td>{r.result}</td>
                 </tr>
               ))}

--- a/frontend/src/app/testResults/TestResultsList.jsx
+++ b/frontend/src/app/testResults/TestResultsList.jsx
@@ -59,7 +59,7 @@ const TestResultsList = () => {
             {displayFullName(firstName, middleName, lastName)}
           </th>
           <td>{lookupId}</td>
-          <td>{moment(result.dateTested).format("MMM DD YYYY")}</td>
+          <td>{moment(result.dateTested).format("lll")}</td>
           <td>{result.result}</td>
           <td>{result.deviceType.name}</td>
         </tr>


### PR DESCRIPTION
https://github.com/CDCgov/prime-central/issues/147

updates the `dateTested` field's format in the `testResults` query to  `yyyy-MM-dd'T'HH:MM:ss'Z'`

example:
```
{
	"data": {
		"testResults": [
			{
				"internalId": "4adf21c2-606c-460b-b6fc-b31551ea7e91",
				"dateTested": "2020-11-30T17:30:31.447Z",
				"result": "POSITIVE",
				"deviceType": {
					"internalId": "0d9fdf04-2259-49d3-b7d9-5c25302a0829",
					"name": "LumiraDX",
					"__typename": "DeviceType"
				},
				"patient": {
					"internalId": "dd481425-453f-4a02-b4fc-e7d2c09c17af",
					"firstName": "tim",
					"middleName": null,
					"lastName": "best",
					"lookupId": "949",
					"__typename": "Patient"
				},
				"__typename": "TestOrder"
			}
		]
	}
}
```
new test results display
![Screen Shot 2020-11-30 at 12 39 58 PM](https://user-images.githubusercontent.com/53869143/100644351-34e3d200-3309-11eb-82e1-746aee6630c6.png)