### PR TITLE
Better property management for development

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# Local properties for Spring Boot--can be a .properties file or .yml/.yaml
+/src/main/resources/application-local.*
+
 ### STS ###
 .apt_generated
 .classpath

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
@@ -2,13 +2,13 @@ package gov.cdc.usds.simplereport.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
-import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 
 /**
@@ -22,13 +22,8 @@ public class DevSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public static final String PROFILE = "no-security";
 
-    public static final class DummyIdentity {
-        public static final String EMAIL = "bob@example.com";
-        public static final String FIRST_NAME = "Bobbity";
-        public static final String MIDDLE_NAME = "Bob";
-        public static final String LAST_NAME = "Bobberoo";
-        public static final String SUFFIX = null;
-    }
+    @Autowired
+    private InitialSetupProperties _setupProps;
 
     @Override
     public void configure(WebSecurity web) {
@@ -40,12 +35,6 @@ public class DevSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	public IdentitySupplier getDummyIdentity() {
-		return () -> new IdentityAttributes(
-			DevSecurityConfiguration.DummyIdentity.EMAIL, 
-			DevSecurityConfiguration.DummyIdentity.FIRST_NAME,
-			DevSecurityConfiguration.DummyIdentity.MIDDLE_NAME,
-			DevSecurityConfiguration.DummyIdentity.LAST_NAME,
-			DevSecurityConfiguration.DummyIdentity.SUFFIX
-		);
+		return _setupProps::getDefaultUser;
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -11,6 +11,7 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
+import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 
 @ConfigurationProperties(prefix = "simple-report-initialization")
 @ConstructorBinding
@@ -20,13 +21,15 @@ public class InitialSetupProperties {
 	private ConfigProvider provider;
 	private List<? extends ConfigDeviceType> deviceTypes;
 	private List<String> configuredDeviceTypes;
+	private IdentityAttributes defaultUser;
 
 	public InitialSetupProperties(ConfigOrganization organization, ConfigProvider provider,
-			List<ConfigDeviceType> deviceTypes, List<String> configuredDeviceTypes) {
+			List<ConfigDeviceType> deviceTypes, List<String> configuredDeviceTypes, IdentityAttributes defaultUser) {
 		this.organization = organization;
 		this.provider = provider;
 		this.deviceTypes = deviceTypes;
 		this.configuredDeviceTypes = configuredDeviceTypes;
+		this.defaultUser = defaultUser;
 	}
 
 	public List<String> getConfiguredDeviceTypeNames() {
@@ -43,6 +46,10 @@ public class InitialSetupProperties {
 
 	public List<? extends DeviceType> getDeviceTypes() {
 		return deviceTypes.stream().map(ConfigDeviceType::getReal).collect(Collectors.toList());
+	}
+
+	public IdentityAttributes getDefaultUser() {
+		return defaultUser;
 	}
 
 	private static final class ConfigOrganization extends Organization {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/model/IdentityAttributes.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/model/IdentityAttributes.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.service.model;
 
+import org.springframework.boot.context.properties.ConstructorBinding;
+
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 
 /**
@@ -9,6 +11,7 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 public class IdentityAttributes extends PersonName {
 	private String username;
 
+	@ConstructorBinding
 	public IdentityAttributes(String username, String firstName, String middleName, String lastName, String suffix) {
 		super(firstName, middleName, lastName, suffix);
 		this.username = username;

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,5 +1,5 @@
 spring:
-  profiles.include: no-security
+  profiles.include: no-security,local
   liquibase:
     user: simple_report_migrations
     password: migrations456
@@ -8,6 +8,15 @@ spring:
       hibernate:
         show_sql: true
         default_schema: simple_report
+logging:
+  level:
+      # NOTE: add any of the below in application-local.yml to turn on something interesting
+      #       (the first two are hibernate SQL query logging, which is pretty verbose, and hibernate
+      #       input and output value logging, which is *incredibly* verbose).
+      # org.hibernate.SQL: DEBUG
+      # org.hibernate.type: TRACE
+      # org.springframework.data.rest=DEBUG
+      gov.cdc.usds: DEBUG
 simple-report-initialization:
   organization:
     facility-name: Dis Organization

--- a/backend/src/main/resources/application-no-security.yml
+++ b/backend/src/main/resources/application-no-security.yml
@@ -1,0 +1,5 @@
+simple-report-initialization.default-user:
+  username: bob@example.com
+  first-name: Bobbity
+  middle-name: Bob
+  last-name: Bobberoo

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 import gov.cdc.usds.simplereport.config.AuditingConfig;
-import gov.cdc.usds.simplereport.config.DevSecurityConfiguration;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
@@ -21,7 +20,7 @@ import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 public class SliceTestConfiguration {
 
 	@Bean
-	public IdentitySupplier dummyIdentityProvider() {
-		return new DevSecurityConfiguration().getDummyIdentity();
+	public IdentitySupplier dummyIdentityProvider(InitialSetupProperties props) {
+		return props::getDefaultUser;
 	}
 }


### PR DESCRIPTION
Added some conveniences for development builds:

* enabled an `application-local.yaml` file to be added to automatically override properties in the `dev` or default profile
* made the default user for the no-security profile configured in properties rather than in code (not sure exactly how these interact—probably worth checking)
* turned on debug logging of the API server for local development