### PR TITLE
Added database-level constraint to prevent duplicate queue entries.

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -476,3 +476,17 @@ databaseChangeLog:
                     foreignKeyName: fk__test_order__test_event
                     references: test_event
                     uniqueKeyName: uk__test_order__test_event
+  - changeSet:
+      id: enforce-queue-uniqueness
+      author: bwarfield@cdc.gov
+      comment: Enforce uniqueness guarantees for patients in the queue.
+      changes:
+        - sql:
+            remarks: Create a unique index on organization and patient, but only for PENDING orders.
+            sql: |
+              CREATE UNIQUE INDEX uk__test_order__organization_person_pending
+              ON ${database.defaultSchemaName}.test_order (organization_id, patient_id)
+              WHERE order_status = 'PENDING'
+      rollback:
+        sql: |
+          DROP INDEX ${database.defaultSchemaName}.uk__test_order__organization_person_pending;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -1,11 +1,18 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 import java.util.List;
 
+import javax.persistence.PersistenceException;
+
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
+
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -15,6 +22,7 @@ import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.test_util.TestDataFactory;
 
 public class TestOrderRepositoryTest extends BaseRepositoryTest {
 
@@ -28,6 +36,8 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 	private ProviderRepository _providers;
 	@Autowired
 	private TestEventRepository _events;
+	@Autowired
+	private TestDataFactory _dataFactory;
 
 	@Test
 	public void runChanges() {
@@ -59,4 +69,61 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		_repo.save(order);
 		flush();
 	}
+
+	@Test
+	public void createOrder_duplicatesFound_error() {
+		Organization org = _dataFactory.createValidOrg();
+		Person patient0 = _dataFactory.createMinimalPerson(org);
+		TestOrder order1 = new TestOrder(patient0, org);
+		_repo.save(order1);
+		flush();
+		TestOrder order2 = new TestOrder(patient0, org);
+		PersistenceException caught = assertThrows(PersistenceException.class, ()->{ _repo.save(order2); flush();});
+		assertEquals(ConstraintViolationException.class, caught.getCause().getClass());
+	}
+
+	@Test
+	public void createOrder_duplicateCanceled_ok() {
+		Organization org = _dataFactory.createValidOrg();
+		Person patient0 = _dataFactory.createMinimalPerson(org);
+		TestOrder order1 = new TestOrder(patient0, org);
+		_repo.save(order1);
+		flush();
+		order1.cancelOrder();
+		_repo.save(order1);
+		flush();
+		TestOrder order2 = new TestOrder(patient0, org);
+		order2 = _repo.save(order2);
+		flush();
+		assertNotNull(order2.getInternalId());
+		assertNotNull(order1.getInternalId());
+		assertNotEquals(order1.getInternalId(), order2.getInternalId());
+		List<TestOrder> queue = _repo.fetchQueueForOrganization(org);
+		assertEquals(1, queue.size());
+		assertEquals(order2.getInternalId(), queue.get(0).getInternalId());
+	}
+
+	@Test
+	public void createOrder_duplicateSubmitted_ok() {
+		Organization org = _dataFactory.createValidOrg();
+		Person patient0 = _dataFactory.createMinimalPerson(org);
+		TestOrder order1 = new TestOrder(patient0, org);
+		_repo.save(order1);
+		flush();
+		TestEvent didit = _events.save(new TestEvent(TestResult.NEGATIVE, org.getDefaultDeviceType(), patient0, org));
+		order1.setTestEvent(didit);
+		order1.setResult(didit.getResult());
+		_repo.save(order1);
+		flush();
+		TestOrder order2 = new TestOrder(patient0, org);
+		order2 = _repo.save(order2);
+		flush();
+		assertNotNull(order2.getInternalId());
+		assertNotNull(order1.getInternalId());
+		assertNotEquals(order1.getInternalId(), order2.getInternalId());
+		List<TestOrder> queue = _repo.fetchQueueForOrganization(org);
+		assertEquals(1, queue.size());
+		assertEquals(order2.getInternalId(), queue.get(0).getInternalId());
+	}
+
 }


### PR DESCRIPTION
To guard against any possible race condition breaking the queue again in the future, added a database constraint that prevents having more than one test order for the same user in the PENDING state at a given point in time.

Also added tests for positive and negative cases, and verified that the test failed before the index was created.

This ticks off the database-related checkbox on #151.