### PR TITLE
Basic alerting for server errors

### DIFF
--- a/frontend/src/app/index.jsx
+++ b/frontend/src/app/index.jsx
@@ -41,7 +41,7 @@ const App = () => {
         <ToastContainer
           autoClose={5000}
           closeButton={false}
-          limit={1}
+          limit={2}
           position="bottom-center"
           hideProgressBar={true}
         />

--- a/frontend/src/app/utils/index.js
+++ b/frontend/src/app/utils/index.js
@@ -1,3 +1,6 @@
+import Alert from "../commonComponents/Alert";
+import React from "react";
+
 export const displayFullName = (first, middle, last) => {
   return `${first || "?"} ${middle || ""} ${last || "?"}`.replace(/ +/g, " ");
 };
@@ -6,15 +9,21 @@ export const isLocalHost = () =>
   Boolean(window.location.hostname === "localhost");
 
 export const showNotification = (toast, children) => {
-  // first, remove any toasts that are currently being rendered.
-  // removing a toast takes an animation time. Default is ~500ms.
-  toast.dismiss();
+  try {
+    // id will de-dup. just use whole message as id
+    const toastId = JSON.stringify(children.props).substr(0, 512);
+    toast(children, { toastId });
+    toast.clearWaitingQueue(); // don't pile up messages
+  } catch (err) {
+    console.error(err, err.stack);
+  }
+};
 
-  // if there is an existing toast, it will be animating away while the new toast is added
-  // this makes it ugly (try commenting out the setTimeout part
-  // to prevent this, add a 500ms delay to all toasts
-  // downside: there is a delay if there isn't an existing toast.
-  setTimeout(() => {
-    toast(children);
-  }, 500);
+export const showError = (
+  toast,
+  message = "Please check for missing data or typos.",
+  title = "Problems saving data to server"
+) => {
+  const err_msg = message.substr(0, 512);
+  showNotification(toast, <Alert type="error" title={title} body={err_msg} />);
 };


### PR DESCRIPTION
- Added a catch-all for graphql errors to display an alert if the server sends back an error for any request.
- Bumped number of messages on screen at any one time up to 2.
- Added de-duplication to showMessages()
- Reworked how showMessages prevents too many errors from showing up at the same time.