### PR TITLE
Fix Okta redirect URL

### DIFF
--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -5,7 +5,7 @@ locals {
     "http://localhost:3000",
     "https://simple-report.app.cloud.gov/",
     "https://prime-data-input-sandbox-backend.app.cloud.gov/",
-    "https://staging.simplereport.org"
+    "https://staging.simplereport.org/app"
   ]
 }
 


### PR DESCRIPTION
Add missing /app suffix to the staging redirect URL