### PR TITLE
Allow access to Spring Boot Healthcheck

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -5,6 +5,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -37,9 +39,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(SecurityConfiguration.class);
 
     public interface OktaAttributes {
-        String EMAIL = "email";
-        String FIRST_NAME = "given_name";
-        String LAST_NAME = "family_name";
+        public static String EMAIL = "email";
+		public static String FIRST_NAME = "given_name";
+		public static String LAST_NAME = "family_name";
     }
 
     @Override
@@ -48,7 +50,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/").permitAll()
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-				.antMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+				.requestMatchers(EndpointRequest.to(HealthEndpoint.class)).permitAll()
                 .anyRequest()
                 .authenticated()
                 .and()

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -37,9 +37,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(SecurityConfiguration.class);
 
     public interface OktaAttributes {
-        public static final String EMAIL = "email";
-        public static final String FIRST_NAME = "given_name";
-        public static final String LAST_NAME = "family_name";
+        String EMAIL = "email";
+        String FIRST_NAME = "given_name";
+        String LAST_NAME = "family_name";
     }
 
     @Override
@@ -48,6 +48,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/").permitAll()
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+				.antMatchers(HttpMethod.GET, "/actuator/health").permitAll()
                 .anyRequest()
                 .authenticated()
                 .and()


### PR DESCRIPTION
Added a GET exception to the SecurityConfiguration, which will allow anonymous access to the overall healthcheck API.

The Gateway can now issue a `GET` request to `/actuator/health` and get a response.

By default, this doesn't expose any internal details on the nested checks, just a simple UP/DOWN status.

Looking at the internal [docs](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-health) Ben linked to, I think it's acceptable to obscure the internal information and simply return UP/DOWN as the health check. In the future, we could expand this to be more detailed, but I think I'd rather move that to a private admin port which we don't route to the world, rather than relying on our auth implementation.

Verified manually that with auth enabled, anonymous access can only hit /health and not anything else like /info.

Closes https://github.com/CDCgov/prime-central/issues/158