### PR TITLE
added basic maintenance page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,9 @@
     "deploy-azure-dev": "REACT_APP_BACKEND_URL=https://dev.simplereport.org/dev/api/graphql PUBLIC_URL=/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportdev --destination-path '/app'",
     "deploy-azure-beta": "REACT_APP_BACKEND_URL=https://simplereport.cdc.gov/api/graphql PUBLIC_URL=/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportbeta --destination-path '/app'",
     "deploy-azure-test": "REACT_APP_BACKEND_URL=https://api.test.simplerport.org PUBLIC_URL=/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name simplereporttestfrontend --destination-path '/app'",
-    "deploy-azure-demo": "REACT_APP_BACKEND_URL=https://demo.simplereport.org/api/graphql PUBLIC_URL=/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportdemo --destination-path '/app'"
+    "deploy-azure-demo": "REACT_APP_BACKEND_URL=https://demo.simplereport.org/api/graphql PUBLIC_URL=/app/ react-scripts build && az storage blob upload-batch -s build/ -d '$web' --account-name usdssimplereportdemo --destination-path '/app'",
+    "maintenance-azure-demo": "mkdir -p /tmp/maintenance && /bin/cp -f public/maintenance.html /tmp/maintenance/index.html && az storage blob upload-batch -s /tmp/maintenance/ -d '$web' --account-name usdssimplereportdemo --destination-path '/app/'",
+    "maintenance-azure-beta": "mkdir -p /tmp/maintenance && /bin/cp -f public/maintenance.html /tmp/maintenance/index.html && az storage blob upload-batch -s /tmp/maintenance/ -d '$web' --account-name usdssimplereportbeta --destination-path '/app/'"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/public/maintenance.html
+++ b/frontend/public/maintenance.html
@@ -1,0 +1,80 @@
+<html lang="en">
+  <head>
+    <title>We'll be right back!</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Lato:100,300"
+    />
+
+    <style>
+      * {
+        transition: all 0.6s;
+      }
+
+      html {
+        height: 100%;
+      }
+
+      body {
+        font-family: "Lato", sans-serif;
+        color: #888;
+        margin: 0;
+      }
+
+      #main {
+        display: table;
+        width: 100%;
+        height: 100vh;
+        text-align: center;
+      }
+
+      .fof {
+        display: table-cell;
+        vertical-align: middle;
+      }
+
+      .fof h1 {
+        font-size: 50px;
+        display: inline-block;
+        padding-right: 12px;
+      }
+      .fof h2 {
+        font-size: 25px;
+        display: inline-block;
+        padding-right: 12px;
+        animation: type 0.5s alternate infinite;
+      }
+
+      @keyframes type {
+        from {
+          box-shadow: inset -3px 0px 0px #888;
+        }
+        to {
+          box-shadow: inset -3px 0px 0px transparent;
+        }
+      }
+    </style>
+
+    <script>
+      window.console = window.console || function (t) {};
+    </script>
+
+    <script>
+      if (document.location.search.match(/type=embed/gi)) {
+        window.parent.postMessage("resize", "*");
+      }
+    </script>
+  </head>
+
+  <body translate="no">
+    <div id="main">
+      <div class="fof">
+        <h1>We are currently performing emergency maintenance.</h1>
+        <h2>Simple Report will be back as soon as possible.</h2>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This adds a very very simple maintenance page with a slightly hacky way to deploy it via npm.

![Screen Shot 2020-12-02 at 4 54 47 PM](https://user-images.githubusercontent.com/51794651/100936268-3f47cc80-34bf-11eb-8ab9-b69ad0402581.png)

Let's say you need to take the app down for some reason (such as maintenance or it's broken), you can run:

```
# demo
npm run maintenance-azure-demo

# beta
npm run maintenance-azure-beta
```

Then when you're done with maintenance, you just run the normal appropriate `npm run deploy-azure-x` to deploy the latest frontend.

It works by just copying a `maintenance.html` file over onto the `index.html` file in the blob storage. There's probably more elegant ways to do this but...  🤷 

