### PR TITLE
Cut JSON deserialization out of test history viewing.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -13,19 +13,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
-import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
 
 public class TestEventExport {
 
-	private TestEvent testEvent;
+	private NoJsonTestEvent testEvent;
 	private Person patient;
 	private AskOnEntrySurvey survey;
 	private Provider provider;
 	private Organization org;
 
-	public TestEventExport(TestEvent testEvent) {
+	public TestEventExport(NoJsonTestEvent testEvent) {
 		super();
 		this.testEvent = testEvent;
 		this.patient = testEvent.getPatientData();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestResult.java
@@ -8,17 +8,17 @@ import org.json.JSONObject;
 
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Organization;
-import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
+import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
 
 
 public class TestResult {
 
-	private TestEvent event;
+	private NoJsonTestEvent event;
 	private AskOnEntrySurvey survey;
 
-	public TestResult(TestEvent event) {
+	public TestResult(NoJsonTestEvent event) {
 		super();
 		this.event = event;
 		this.survey = event.getTestOrder().getAskOnEntrySurvey().getSurvey();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueResolver.java
@@ -24,7 +24,7 @@ public class QueueResolver implements GraphQLQueryResolver {
 
 	public List<TestResult> getTestResults() {
 		return tos.getTestResults().stream()
-			.map(r -> new TestResult(r.getTestEvent()))
+			.map(TestResult::new)
 			.collect(Collectors.toList());
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/NoJsonTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/NoJsonTestOrder.java
@@ -1,0 +1,157 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.Map;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.FetchType;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Type;
+import org.json.JSONObject;
+
+import gov.cdc.usds.simplereport.db.model.auxiliary.OrderStatus;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
+
+@Entity
+@Table(name = "test_order")
+public class NoJsonTestOrder extends AuditedEntity {
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "patient_id")
+	private Person patient;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "patient_answers_id" )
+	private PatientAnswers askOnEntrySurvey;
+	@ManyToOne(optional = true)
+	@JoinColumn(name = "device_type_id")
+	private DeviceType deviceType;
+	@Column
+	private LocalDate dateTested;
+	@Column(nullable = false)
+	@Type(type = "pg_enum")
+	@Enumerated(EnumType.STRING)
+	private OrderStatus orderStatus;
+	@Column(nullable = true)
+	@Type(type = "pg_enum")
+	@Enumerated(EnumType.STRING)
+	private TestResult result;
+	@OneToOne(optional = true)
+	@JoinColumn(name="test_event_id")
+	private NoJsonTestEvent testEvent;
+
+	protected NoJsonTestOrder() { /* for hibernate */ }
+
+	public NoJsonTestOrder(Person patient, Organization organization, OrderStatus orderStatus, TestResult result) {
+		this.patient = patient;
+		this.organization = organization;
+		this.orderStatus = orderStatus;
+		this.result = result;
+	}
+	public NoJsonTestOrder(Person patient, Organization org) {
+		this(patient, org, OrderStatus.PENDING, null);
+	}
+	public Person getPatient() {
+		return patient;
+	}
+	public Organization getOrganization() {
+		return organization;
+	}
+	public OrderStatus getOrderStatus() {
+		return orderStatus;
+	}
+
+	public void setAskOnEntrySurvey(PatientAnswers askOnEntrySurvey) {
+		this.askOnEntrySurvey = askOnEntrySurvey;
+	}
+
+	public PatientAnswers getAskOnEntrySurvey() {
+		return askOnEntrySurvey;
+	}
+
+	public TestResult getTestResult() {
+		return result;
+	}
+
+	public Date getDateAdded() {
+		return getCreatedAt();
+	}
+
+	public LocalDate getDateTested() {
+		return dateTested;
+	}
+
+	public DeviceType getDeviceType() {
+		return deviceType;
+	}
+
+	public void setResult(TestResult finalResult) {
+		result = finalResult;
+		dateTested = LocalDate.now();
+		orderStatus = OrderStatus.COMPLETED;
+	}
+
+	public void cancelOrder() {
+		orderStatus = OrderStatus.CANCELED;
+	}
+
+	public NoJsonTestEvent getTestEvent() {
+		return testEvent;
+	}
+	public void setTestEvent(NoJsonTestEvent testEvent) {
+		this.testEvent = testEvent;
+	}
+
+	public String getPregnancy() {
+		return askOnEntrySurvey.getSurvey().getPregnancy();
+	}
+
+	public String getSymptoms() {
+		Map<String, Boolean> s = askOnEntrySurvey.getSurvey().getSymptoms();
+		JSONObject obj = new JSONObject();
+		for (Map.Entry<String,Boolean> entry : s.entrySet()) {
+			obj.put(entry.getKey(), entry.getValue().toString());
+		}
+		return obj.toString();
+	}
+
+	public Boolean getFirstTest() {
+		return askOnEntrySurvey.getSurvey().getFirstTest();
+	}
+
+	public LocalDate getPriorTestDate() {
+		return askOnEntrySurvey.getSurvey().getPriorTestDate();
+	}
+
+	public String getPriorTestType() {
+		return askOnEntrySurvey.getSurvey().getPriorTestType();
+	}
+
+	public String getPriorTestResult() {
+		TestResult result = askOnEntrySurvey.getSurvey().getPriorTestResult();
+		return result == null ? "" : result.toString();
+	}
+
+	public LocalDate getSymptomOnset() {
+		return askOnEntrySurvey.getSurvey().getSymptomOnsetDate();
+	}
+
+	public Boolean getNoSymptoms() {
+		return askOnEntrySurvey.getSurvey().getNoSymptoms();
+	}
+
+	public void setDeviceType(DeviceType deviceType) {
+		this.deviceType = deviceType;
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
@@ -17,8 +17,8 @@ import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
-import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.db.model.NoJsonTestOrder;
 
 @Entity
 @Table(name = "test_event")
@@ -39,7 +39,7 @@ public class NoJsonTestEvent extends AuditedEntity {
 	@JoinColumn(name = "device_type_id")
 	private DeviceType deviceType;
 	@OneToOne(mappedBy = "testEvent")
-	private TestOrder order;
+	private NoJsonTestOrder order;
 
 	protected NoJsonTestEvent() { /* no-op */ }
 
@@ -59,7 +59,7 @@ public class NoJsonTestEvent extends AuditedEntity {
 		return deviceType;
 	}
 
-	public TestOrder getTestOrder() {
+	public NoJsonTestOrder getTestOrder() {
 		return order;
 	}
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
@@ -1,0 +1,73 @@
+package gov.cdc.usds.simplereport.db.model.readonly;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Type;
+
+import gov.cdc.usds.simplereport.db.model.AuditedEntity;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+
+@Entity
+@Table(name = "test_event")
+@Immutable
+public class NoJsonTestEvent extends AuditedEntity {
+
+	@Column
+	@Type(type = "pg_enum")
+	@Enumerated(EnumType.STRING)
+	private TestResult result;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "patient_id")
+	private Person patient;
+	@ManyToOne
+	@JoinColumn(name = "device_type_id")
+	private DeviceType deviceType;
+	@OneToOne(mappedBy = "testEvent")
+	private TestOrder order;
+
+	protected NoJsonTestEvent() { /* no-op */ }
+
+	public TestResult getResult() {
+		return result;
+	}
+
+	public Organization getOrganization() {
+		return organization;
+	}
+
+	public Person getPatient() {
+		return patient;
+	}
+
+	public DeviceType getDeviceType() {
+		return deviceType;
+	}
+
+	public TestOrder getTestOrder() {
+		return order;
+	}
+
+	public Person getPatientData() {
+		return getPatient();
+	}
+
+	public Provider getProviderData() {
+		return getOrganization().getOrderingProvider();
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/NoJsonTestEventRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/NoJsonTestEventRepository.java
@@ -1,0 +1,15 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.repository.Repository;
+
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
+
+public interface NoJsonTestEventRepository extends Repository<NoJsonTestEvent, UUID> {
+
+	public List<NoJsonTestEvent> findAllByOrganization(Organization o);
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ExportService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ExportService.java
@@ -1,16 +1,18 @@
 package gov.cdc.usds.simplereport.service;
 
-import com.fasterxml.jackson.dataformat.csv.CsvMapper;
-import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
-import gov.cdc.usds.simplereport.db.model.TestEvent;
-import gov.cdc.usds.simplereport.api.model.TestEventExport;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+
+import gov.cdc.usds.simplereport.api.model.TestEventExport;
+import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
+import gov.cdc.usds.simplereport.db.repository.NoJsonTestEventRepository;
 
 /**
  * Created by nickrobison on 11/21/20
@@ -19,17 +21,17 @@ import java.util.List;
 @Transactional
 public class ExportService {
 
-    private final TestEventRepository _ts;
+    private final NoJsonTestEventRepository _ts;
     private OrganizationService _os;
 
 
-    public ExportService(TestEventRepository ts, OrganizationService os) {
+    public ExportService(NoJsonTestEventRepository ts, OrganizationService os) {
         this._ts = ts;
         this._os = os;
     }
 
     public String CreateTestEventCSV() throws IOException {
-      List<TestEvent> events = _ts.findAllByOrganization(_os.getCurrentOrganization());
+      List<NoJsonTestEvent> events = _ts.findAllByOrganization(_os.getCurrentOrganization());
       List<TestEventExport> eventsToExport = new ArrayList<>();
       events.forEach(e -> eventsToExport.add(new TestEventExport(e)));
       CsvMapper mapper = new CsvMapper();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -18,7 +18,9 @@ import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
+import gov.cdc.usds.simplereport.db.repository.NoJsonTestEventRepository;
 import gov.cdc.usds.simplereport.db.repository.PatientAnswersRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
@@ -36,6 +38,7 @@ public class TestOrderService {
   private PatientAnswersRepository _parepo;
   private TestEventRepository _terepo;
   private PersonRepository _prepo;
+  private NoJsonTestEventRepository _noJsonEventRepo;
 
   public TestOrderService(
     OrganizationService os,
@@ -43,6 +46,7 @@ public class TestOrderService {
     TestOrderRepository repo,
     PatientAnswersRepository parepo,
     TestEventRepository terepo,
+    NoJsonTestEventRepository njterepo,
     PersonRepository prepo
   ) {
     _os = os;
@@ -51,14 +55,15 @@ public class TestOrderService {
     _parepo = parepo;
     _terepo = terepo;
     _prepo = prepo;
+    _noJsonEventRepo = njterepo;
 }
 
 	public List<TestOrder> getQueue() {
 		return _repo.fetchQueueForOrganization(_os.getCurrentOrganization());
 	}
 
-  public List<TestOrder> getTestResults() {
-		return _repo.fetchPastResultsForOrganization(_os.getCurrentOrganization());
+  public List<NoJsonTestEvent> getTestResults() {
+	  return _noJsonEventRepo.findAllByOrganization(_os.getCurrentOrganization());
   }
 
   public void addTestResult(String deviceID, TestResult result, String patientId) {

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -7,16 +7,17 @@ spring:
     properties:
       hibernate:
         show_sql: true
+        format_sql: true
         default_schema: simple_report
 logging:
   level:
-      # NOTE: add any of the below in application-local.yml to turn on something interesting
-      #       (the first two are hibernate SQL query logging, which is pretty verbose, and hibernate
-      #       input and output value logging, which is *incredibly* verbose).
-      # org.hibernate.SQL: DEBUG
-      # org.hibernate.type: TRACE
-      # org.springframework.data.rest=DEBUG
-      gov.cdc.usds: DEBUG
+    # NOTE: add any of the below in application-local.yml to turn on something interesting
+    #       (the first two are hibernate SQL query logging, which is pretty verbose, and hibernate
+    #       input and output value logging, which is *incredibly* verbose).
+    # org.hibernate.SQL: DEBUG
+    # org.hibernate.type: TRACE
+    # org.springframework.data.rest=DEBUG
+    gov.cdc.usds: DEBUG
 simple-report-initialization:
   organization:
     facility-name: Dis Organization


### PR DESCRIPTION
Created a separate entity that cannot be saved or updated and draws its data from the test_event table, but does not know about the two jsonb columns. Updated all code that queries for test events to query this new entity instead. This punts the problem of dealing with different versions of our JSON-serialized objects a reasonable distance into the future.