### PR TITLE
Add GraphQL logging support

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLInstrumentationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLInstrumentationService.java
@@ -1,0 +1,24 @@
+package gov.cdc.usds.simplereport.logging;
+
+import graphql.execution.instrumentation.Instrumentation;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by nickrobison on 11/27/20
+ */
+@Service
+public class GraphQLInstrumentationService {
+
+    GraphQLInstrumentationService() {
+        // Not used
+    }
+
+    @Bean
+    List<Instrumentation> instrumentations() {
+        return new ArrayList<>(List.of(new QueryLoggingInstrumentation()));
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
@@ -1,0 +1,54 @@
+package gov.cdc.usds.simplereport.logging;
+
+import graphql.language.Field;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.Stream;
+
+/**
+ * Collection of helpers for parsing and logging the GraphQL queries and results
+ */
+public class GraphQLLoggingHelpers {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GraphQLLoggingHelpers.class);
+
+    private GraphQLLoggingHelpers() {
+        // Not used
+    }
+
+    /**
+     * Recursive method for walking the GraphQL query structure and collecting the names of the fields being selected,
+     * along with any provided arguments.
+     * <p>
+     * If a parent name is provided (e.g. not blank), it's used to provide some additional type clarity to the output (e.g. patient:internalID)
+     * If the {@link Selection} object does not have any sub-selections {@link Field#getSelectionSet()} is {@code null}, then it simply returns a {@link Stream} of the single formatted field name
+     *
+     * @param parentName - {@link String} name of parent
+     * @param selection  - {@link Selection} to process
+     * @return - {@link Stream} of field name {@link String} values
+     */
+    public static Stream<String> walkFields(String parentName, Selection selection) {
+        final Field field = (Field) selection;
+        final String fieldName = field.getName();
+
+        if (!field.getArguments().isEmpty()) {
+            LOG.info("Selecting {} with arguments: {}", fieldName, field.getArguments());
+        }
+
+        final SelectionSet selections = field.getSelectionSet();
+        if (selections == null) {
+            final String formattedFieldName;
+            if (parentName.isBlank()) {
+                formattedFieldName = fieldName;
+            } else {
+                formattedFieldName = String.format("%s:%s", parentName, fieldName);
+            }
+            return Stream.of(formattedFieldName);
+        }
+
+        return selections.getSelections().stream().filter(s -> s instanceof Field).flatMap(f -> GraphQLLoggingHelpers.walkFields(fieldName, f));
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/GraphQLLoggingHelpers.java
@@ -75,11 +75,12 @@ public class GraphQLLoggingHelpers {
 
                 if (t != null) {
                     LOG.error("GraphQL execution failed: {}", t.getMessage(), t);
+                    LOG.info("GraphQL execution FAILED in {}ms", queryDuration.toMillis());
                 } else if (!result.getErrors().isEmpty()) {
                     result.getErrors().forEach(error -> LOG.error("Query failed with error {}", error));
-                    LOG.info("Graphql execution failed in {}ms", queryDuration.toMillis());
+                    LOG.info("GraphQL execution FAILED in {}ms", queryDuration.toMillis());
                 } else {
-                    LOG.info("GraphQL execution completed in {}ms", queryDuration.toMillis());
+                    LOG.info("GraphQL execution COMPLETED in {}ms", queryDuration.toMillis());
                 }
                 // Clear the MDC context
                 MDC.remove(GRAPHQL_QUERY_MDC_KEY);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -1,0 +1,48 @@
+package gov.cdc.usds.simplereport.logging;
+
+import graphql.ExecutionResult;
+import graphql.execution.ExecutionId;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by nickrobison on 11/27/20
+ */
+public class QueryLoggingInstrumentation extends SimpleInstrumentation {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueryLoggingInstrumentation.class);
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
+        final long queryStart = System.currentTimeMillis();
+        final ExecutionId executionId = parameters.getExecutionInput().getExecutionId();
+
+        if (LOG.isInfoEnabled()) {
+            final String query = parameters.getQuery();
+            LOG.info("[{}] query: {}", executionId, query);
+
+            if (parameters.getVariables() != null && !parameters.getVariables().isEmpty()) {
+                LOG.info("[{}] variables: {}", executionId, parameters.getVariables());
+            }
+        }
+
+        return new SimpleInstrumentationContext<>() {
+            @Override
+            public void onCompleted(ExecutionResult result, Throwable t) {
+                if (LOG.isInfoEnabled()) {
+                    final long queryEnd = System.currentTimeMillis();
+
+                    if (t != null) {
+                        LOG.info("GraphQL execution {} failed: {}", executionId, t.getMessage(), t);
+                    } else {
+                        LOG.info("[{}] query completed in {}ms", executionId, queryEnd - queryStart);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/logging/QueryLoggingInstrumentation.java
@@ -6,8 +6,17 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.SimpleInstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.validation.ValidationError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created by nickrobison on 11/27/20
@@ -15,19 +24,36 @@ import org.slf4j.LoggerFactory;
 public class QueryLoggingInstrumentation extends SimpleInstrumentation {
 
     private static final Logger LOG = LoggerFactory.getLogger(QueryLoggingInstrumentation.class);
+    private static final String GRAPHQL_QUERY = "graphql-query";
+
+    @Override
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
+
+        // Let's try to pull out some interesting things
+        final Set<String> fieldSet = parameters
+                .getDocument()
+                .getDefinitions()
+                .stream()
+                .filter(definition -> definition instanceof OperationDefinition)
+                .flatMap(definition -> ((OperationDefinition) definition).getSelectionSet().getSelections().stream())
+                .filter(selection -> selection instanceof Field)
+                .flatMap(selection -> GraphQLLoggingHelpers.walkFields("", selection))
+                .collect(Collectors.toSet());
+//
+        LOG.info("Selecting fields: {}", fieldSet);
+        return super.beginValidation(parameters);
+    }
 
     @Override
     public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
         final long queryStart = System.currentTimeMillis();
         final ExecutionId executionId = parameters.getExecutionInput().getExecutionId();
 
-        if (LOG.isInfoEnabled()) {
-            final String query = parameters.getQuery();
-            LOG.info("[{}] query: {}", executionId, query);
+        // Add the execution ID to the sfl4j MDC
+        MDC.put(GRAPHQL_QUERY, executionId.toString());
 
-            if (parameters.getVariables() != null && !parameters.getVariables().isEmpty()) {
-                LOG.info("[{}] variables: {}", executionId, parameters.getVariables());
-            }
+        if (LOG.isInfoEnabled() && parameters.getVariables() != null && !parameters.getVariables().isEmpty()) {
+            LOG.info("GraphQL variables: {}", parameters.getVariables());
         }
 
         return new SimpleInstrumentationContext<>() {
@@ -37,11 +63,16 @@ public class QueryLoggingInstrumentation extends SimpleInstrumentation {
                     final long queryEnd = System.currentTimeMillis();
 
                     if (t != null) {
-                        LOG.info("GraphQL execution {} failed: {}", executionId, t.getMessage(), t);
+                        LOG.info("GraphQL execution failed: {}", t.getMessage(), t);
+                    } else if (!result.getErrors().isEmpty()) {
+                        result.getErrors().forEach(error -> LOG.error("Query failed with error {}", error));
+                        LOG.info("Graphql execution failed in {}ms", queryEnd - queryStart);
                     } else {
-                        LOG.info("[{}] query completed in {}ms", executionId, queryEnd - queryStart);
+                        LOG.info("GraphQL execution completed in {}ms", queryEnd - queryStart);
                     }
                 }
+                // Clear the MDC context
+                MDC.remove(GRAPHQL_QUERY);
             }
         };
     }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -51,3 +51,6 @@ simple-report-initialization:
       manufacturer: LumiraDx UK Ltd.
       model: LumiraDx SARS-CoV-2 Ag Test*
       loinc-code: "95209-3"
+logging:
+  pattern:
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} [Query: %X{graphql-query}] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"


### PR DESCRIPTION
Initial work on added some better logging for our GraphQL backend.

Given that the default logging setup for GraphQL isn't very helpful, we need to create out own handlers to try and improve things a bit. This PR adds the first scaffolding for doing so, and tries to pull out some helpful information, such as the Query ID and the fields being selected. It also actually returns errors being generated by the backend and logs them appropriately.

Some sample logging output:

```
2020-12-03 11:17:44.204  INFO 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.logging.GraphQLFieldWalker       : Selecting addPatient with arguments: [Argument{name='lookupId', value=StringValue{value='nick-1'}}, Argument{name='firstName', value=StringValue{value='Nick'}}, Argument{name='lastName', value=StringValue{value='Robison'}}, Argument{name='birthDate', value=StringValue{value='1989-03-26'}}]
2020-12-03 11:17:44.205  INFO 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Selecting fields: [:addPatient]
2020-12-03 11:17:44.223  WARN 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] notprivacysafe.graphql.GraphQL           : Query failed to validate : 'mutation {
  addPatient(lookupId: "nick-1", firstName: "Nick", lastName: "Robison", birthDate: "1989-03-26")
}
'
2020-12-03 11:17:46.572 ERROR 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Query failed with error ValidationError{validationErrorType=MissingFieldArgument, queryPath=[addPatient], message=Validation error of type MissingFieldArgument: Missing field argument street @ 'addPatient', locations=[SourceLocation{line=2, column=3}], description='Missing field argument street'}
2020-12-03 11:17:46.572 ERROR 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Query failed with error ValidationError{validationErrorType=MissingFieldArgument, queryPath=[addPatient], message=Validation error of type MissingFieldArgument: Missing field argument state @ 'addPatient', locations=[SourceLocation{line=2, column=3}], description='Missing field argument state'}
2020-12-03 11:17:46.572 ERROR 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Query failed with error ValidationError{validationErrorType=MissingFieldArgument, queryPath=[addPatient], message=Validation error of type MissingFieldArgument: Missing field argument zipCode @ 'addPatient', locations=[SourceLocation{line=2, column=3}], description='Missing field argument zipCode'}
2020-12-03 11:17:46.572 ERROR 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Query failed with error ValidationError{validationErrorType=MissingFieldArgument, queryPath=[addPatient], message=Validation error of type MissingFieldArgument: Missing field argument telephone @ 'addPatient', locations=[SourceLocation{line=2, column=3}], description='Missing field argument telephone'}
2020-12-03 11:17:46.572 ERROR 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Query failed with error ValidationError{validationErrorType=MissingFieldArgument, queryPath=[addPatient], message=Validation error of type MissingFieldArgument: Missing field argument residentCongregateSetting @ 'addPatient', locations=[SourceLocation{line=2, column=3}], description='Missing field argument residentCongregateSetting'}
2020-12-03 11:17:46.572 ERROR 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Query failed with error ValidationError{validationErrorType=MissingFieldArgument, queryPath=[addPatient], message=Validation error of type MissingFieldArgument: Missing field argument employedInHealthcare @ 'addPatient', locations=[SourceLocation{line=2, column=3}], description='Missing field argument employedInHealthcare'}
2020-12-03 11:17:46.572  INFO 59679 --- [nio-8080-exec-1] [Query: 5a5b77a6-162b-4ab4-bbbc-e40ba1b7722b] g.c.u.s.l.QueryLoggingInstrumentation    : Graphql execution failed in 2400ms
```

The logging backend also adds the GraphQL query ID to the MDC map, so any other log messages (e.g. Hibernate) will be tagged correctly.

One decision we need to make is which fields to actually log as arguments.
If we have any fields with PII we'll need to mark them appropriately, maybe by using a custom GraphQL attribute.

Partially addresses #195.