### PR TITLE
Add logout redirect url for Okta

### DIFF
--- a/ops/services/all-persistent/main.tf
+++ b/ops/services/all-persistent/main.tf
@@ -1,9 +1,3 @@
-// Okta application
-module "okta" {
-  source = "../../services/okta-app"
-  env = var.env
-}
-
 locals {
   management_tags = {
     prime-app = "simplereport"
@@ -49,6 +43,12 @@ module "db" {
   rg_location = data.azurerm_resource_group.rg.location
   rg_name = data.azurerm_resource_group.rg.name
   tags = local.management_tags
+}
+
+// Okta application
+module "okta" {
+  source = "../../services/okta-app"
+  env = var.env
 }
 
 // Create the Okta secrets

--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -23,6 +23,9 @@ resource "okta_app_oauth" "app" {
     "id_token",
     "token"]
   login_uri = "https://prime-data-input-sandbox-backend.app.cloud.gov/"
+  post_logout_redirect_uris = [
+    "https://simplereport.cdc.gov"
+  ]
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
Add simplereport.cdc.gov as a valid redirect URL on logout.

Re-ordered the all-persistent module to put the Okta module where it belongs.

Adds backend support for #216 