### PR TITLE
Persistence refactor

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/AuditedEntity.java
@@ -44,7 +44,7 @@ public abstract class AuditedEntity {
 	@CreatedBy
 	@Immutable // not sure this is needed. Not sure it works if it is. :-(
 	@ManyToOne(optional = false)
-	@JoinColumn(name="created_by")
+	@JoinColumn(name="created_by", updatable = false)
 	private ApiUser createdBy;
 
 	@LastModifiedBy

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -1,26 +1,50 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
+
+import org.hibernate.annotations.Type;
+
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @MappedSuperclass
 public abstract class BaseTestInfo extends AuditedEntity {
 
 	@ManyToOne(optional = false)
-	@JoinColumn(name = "patient_id")
+	@JoinColumn(name = "patient_id", updatable = false)
 	private Person patient;
+
 	@ManyToOne(optional = false)
-	@JoinColumn(name = "organization_id")
+	@JoinColumn(name = "organization_id", updatable = false)
 	private Organization organization;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "device_type_id")
+	private DeviceType deviceType;
+
+	@Column(nullable = true)
+	@Type(type = "pg_enum")
+	@Enumerated(EnumType.STRING)
+	private TestResult result;
 
 	protected BaseTestInfo() {
 		super();
 	}
 
-	protected BaseTestInfo(Person patient) {
-		this.organization = patient.getOrganization();
+	public BaseTestInfo(Person patient, Organization organization, DeviceType deviceType, TestResult result) {
+		super();
 		this.patient = patient;
+		this.organization = organization;
+		this.deviceType = deviceType;
+		this.result = result;
+	}
+
+	protected BaseTestInfo(Person patient) {
+		this(patient, patient.getOrganization(), patient.getOrganization().getDefaultDeviceType(), null);
 	}
 
 	public Person getPatient() {
@@ -31,4 +55,19 @@ public abstract class BaseTestInfo extends AuditedEntity {
 		return organization;
 	}
 
+	public DeviceType getDeviceType() {
+		return deviceType;
+	}
+
+	public TestResult getResult() {
+		return result;
+	}
+
+	protected void setTestResult(TestResult newResult) {
+		result = newResult;
+	}
+
+	protected void setDeviceType(DeviceType deviceType) {
+		this.deviceType = deviceType;
+	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -12,7 +12,8 @@ import org.hibernate.annotations.Type;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @MappedSuperclass
-public abstract class BaseTestInfo extends AuditedEntity {
+public abstract class BaseTestInfo extends AuditedEntity
+		implements OrganizationScoped {
 
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "patient_id", updatable = false)
@@ -51,6 +52,7 @@ public abstract class BaseTestInfo extends AuditedEntity {
 		return patient;
 	}
 
+	@Override
 	public Organization getOrganization() {
 		return organization;
 	}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -1,0 +1,34 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class BaseTestInfo extends AuditedEntity {
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "patient_id")
+	private Person patient;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+
+	protected BaseTestInfo() {
+		super();
+	}
+
+	protected BaseTestInfo(Person patient) {
+		this.organization = patient.getOrganization();
+		this.patient = patient;
+	}
+
+	public Person getPatient() {
+		return patient;
+	}
+
+	public Organization getOrganization() {
+		return organization;
+	}
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScoped.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScoped.java
@@ -1,0 +1,24 @@
+package gov.cdc.usds.simplereport.db.model;
+
+/**
+ * Marker interface for an entity that is tied to a specific {@link Organization}.
+ * Generally speaking, the Organization is not exposed to the user, because the user
+ * is only authorized to items that belong to their own organization: rather, entities
+ * with this interface should always be filtered by organization, and are candidates
+ * for database-managed row-level security.
+ */
+public interface OrganizationScoped {
+
+	/**
+	 * The organization to which this entity belongs. The only time you should
+	 * actually need to call this method is when you are initializing a new
+	 * {@link OrganizationScoped} entity based on a relationship to another
+	 * entity within the same organization, at which point initializing the
+	 * {@code organization} field of the new entity should be done based on the
+	 * related entity, rather than requiring the organization to be passed in
+	 * separately. 
+	 * @return a non-null {@link Organization} object.
+	 */
+	Organization getOrganization();
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScopedEternalEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScopedEternalEntity.java
@@ -1,0 +1,29 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@MappedSuperclass
+public class OrganizationScopedEternalEntity extends EternalEntity {
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "organization_id", updatable = false)
+	@JsonIgnore
+	private Organization organization;
+
+	public OrganizationScopedEternalEntity() {
+		super();
+	}
+
+	public OrganizationScopedEternalEntity(Organization org) {
+		organization = org;
+	}
+
+	public Organization getOrganization() {
+		return organization;
+	}
+
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScopedEternalEntity.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/OrganizationScopedEternalEntity.java
@@ -7,7 +7,8 @@ import javax.persistence.MappedSuperclass;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @MappedSuperclass
-public class OrganizationScopedEternalEntity extends EternalEntity {
+public class OrganizationScopedEternalEntity extends EternalEntity
+		implements OrganizationScoped {
 
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "organization_id", updatable = false)
@@ -22,6 +23,7 @@ public class OrganizationScopedEternalEntity extends EternalEntity {
 		organization = org;
 	}
 
+	@Override
 	public Organization getOrganization() {
 		return organization;
 	}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -11,14 +11,13 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import java.time.LocalDate;
 import java.util.List;
 
 
 @Entity
-public class Person extends EternalEntity {
+public class Person extends OrganizationScopedEternalEntity {
 
 	@Column
 	private String lookupId;
@@ -47,10 +46,6 @@ public class Person extends EternalEntity {
 	private PersonRole role;
 	@Column(nullable = false)
 	private boolean residentCongregateSetting;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "organization_id")
-	@JsonIgnore // don't descend this model graph when serializing for TestEvent
-	private Organization organization;
 	@OneToMany()
 	@JoinColumn(name = "patient_id")
 	@JsonIgnore // dear Lord do not attempt to serialize this
@@ -59,7 +54,7 @@ public class Person extends EternalEntity {
 	protected Person() { /* for hibernate */ }
 
 	public Person(String firstName, String middleName, String lastName, String suffix, Organization org) {
-		this.organization = org;
+		super(org);
 		this.nameInfo = new PersonName(firstName, middleName, lastName, suffix);
 		this.role = PersonRole.STAFF;
 	}
@@ -86,12 +81,12 @@ public class Person extends EternalEntity {
 		Boolean residentCongregateSetting,
 		Boolean employedInHealthcare
 	) {
+		super(organization);
 		this.lookupId = lookupId;
 		this.nameInfo = new PersonName(firstName, middleName, lastName, suffix);
 		this.birthDate = birthDate;
 		this.telephone = telephone;
 		this.address = address;
-		this.organization = organization;
 		this.role = role;
 		this.email = email;
 		this.race = race;
@@ -186,10 +181,6 @@ public class Person extends EternalEntity {
 	public Boolean getEmployedInHealthcare() {
 		return employedInHealthcare;
 	}
-	public Organization getOrganization() {
-		return organization;
-	}
-
 	@JsonIgnore
 	public String getStreet() {
 		if(address == null || address.getStreet() == null || address.getStreet().isEmpty()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -15,19 +15,13 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @Entity
 @Immutable
-public class TestEvent extends AuditedEntity {
+public class TestEvent extends BaseTestInfo {
 
-	@Column
+	@Column(nullable = false)
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
 	private TestResult result;
 	@ManyToOne(optional = false)
-	@JoinColumn(name = "organization_id")
-	private Organization organization;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "patient_id")
-	private Person patient;
-	@ManyToOne
 	@JoinColumn(name = "device_type_id")
 	private DeviceType deviceType;
 	@Column
@@ -42,13 +36,12 @@ public class TestEvent extends AuditedEntity {
 	public TestEvent() {}
 
 	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Organization org) {
+		super(patient);
 		this.result = result;
 		this.deviceType = deviceType;
 		// store a link, and *also* store the object as JSON
-		this.patient = patient;
 		this.patientData = patient;
-		this.organization = org;
-		this.providerData = org.getOrderingProvider();
+		this.providerData = patient.getOrganization().getOrderingProvider();
 	}
 
 	public TestResult getResult() {
@@ -65,14 +58,6 @@ public class TestEvent extends AuditedEntity {
 
 	public Provider getProviderData() {
 		return providerData;
-	}
-
-	public Organization getOrganization() {
-		return organization;
-	}
-
-	public Person getPatient() {
-		return patient;
 	}
 
 	public TestOrder getTestOrder() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -28,7 +28,6 @@ public class TestEvent extends BaseTestInfo {
 
 	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Organization org) {
 		super(patient, org, deviceType, result);
-		this.setTestResult(result);
 		// store a link, and *also* store the object as JSON
 		this.patientData = getPatient();
 		this.providerData = getOrganization().getOrderingProvider();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -1,11 +1,8 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 
 import org.hibernate.annotations.Immutable;
@@ -15,15 +12,9 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @Entity
 @Immutable
+@AttributeOverride(name = "result", column = @Column(nullable = false))
 public class TestEvent extends BaseTestInfo {
 
-	@Column(nullable = false)
-	@Type(type = "pg_enum")
-	@Enumerated(EnumType.STRING)
-	private TestResult result;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "device_type_id")
-	private DeviceType deviceType;
 	@Column
 	@Type(type = "jsonb")
 	private Person patientData;
@@ -36,20 +27,11 @@ public class TestEvent extends BaseTestInfo {
 	public TestEvent() {}
 
 	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Organization org) {
-		super(patient);
-		this.result = result;
-		this.deviceType = deviceType;
+		super(patient, org, deviceType, result);
+		this.setTestResult(result);
 		// store a link, and *also* store the object as JSON
-		this.patientData = patient;
-		this.providerData = patient.getOrganization().getOrderingProvider();
-	}
-
-	public TestResult getResult() {
-		return result;
-	}
-
-	public DeviceType getDeviceType() {
-		return deviceType;
+		this.patientData = getPatient();
+		this.providerData = getOrganization().getOrderingProvider();
 	}
 
 	public Person getPatientData() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -19,14 +19,8 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.OrderStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @Entity
-public class TestOrder extends AuditedEntity {
+public class TestOrder extends BaseTestInfo {
 
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "patient_id")
-	private Person patient;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "organization_id")
-	private Organization organization;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "patient_answers_id" )
 	private PatientAnswers askOnEntrySurvey;
@@ -49,20 +43,10 @@ public class TestOrder extends AuditedEntity {
 
 	protected TestOrder() { /* for hibernate */ }
 
-	public TestOrder(Person patient, Organization organization, OrderStatus orderStatus, TestResult result) {
-		this.patient = patient;
-		this.organization = organization;
-		this.orderStatus = orderStatus;
-		this.result = result;
-	}
-	public TestOrder(Person patient, Organization org) {
-		this(patient, org, OrderStatus.PENDING, null);
-	}
-	public Person getPatient() {
-		return patient;
-	}
-	public Organization getOrganization() {
-		return organization;
+	public TestOrder(Person patient) {
+		super(patient);
+		this.orderStatus = OrderStatus.PENDING;
+		this.result = null;
 	}
 	public OrderStatus getOrderStatus() {
 		return orderStatus;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -7,10 +7,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
-import javax.persistence.FetchType;
 
 import org.hibernate.annotations.Type;
 import org.json.JSONObject;
@@ -24,19 +24,12 @@ public class TestOrder extends BaseTestInfo {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "patient_answers_id" )
 	private PatientAnswers askOnEntrySurvey;
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "device_type_id")
-	private DeviceType deviceType;
 	@Column
 	private LocalDate dateTested;
 	@Column(nullable = false)
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
 	private OrderStatus orderStatus;
-	@Column(nullable = true)
-	@Type(type = "pg_enum")
-	@Enumerated(EnumType.STRING)
-	private TestResult result;
 	@OneToOne(optional = true)
 	@JoinColumn(name="test_event_id")
 	private TestEvent testEvent;
@@ -46,7 +39,6 @@ public class TestOrder extends BaseTestInfo {
 	public TestOrder(Person patient) {
 		super(patient);
 		this.orderStatus = OrderStatus.PENDING;
-		this.result = null;
 	}
 	public OrderStatus getOrderStatus() {
 		return orderStatus;
@@ -60,20 +52,16 @@ public class TestOrder extends BaseTestInfo {
 		return askOnEntrySurvey;
 	}
 
-	public TestResult getTestResult() {
-		return result;
-	}
-
 	public LocalDate getDateTested() {
 		return dateTested;
 	}
 
-	public DeviceType getDeviceType() {
-		return deviceType;
+	public TestResult getTestResult() {
+		return getResult();
 	}
 
 	public void setResult(TestResult finalResult) {
-		result = finalResult;
+		super.setTestResult(finalResult);
 		dateTested = LocalDate.now();
 		orderStatus = OrderStatus.COMPLETED;
 	}
@@ -128,6 +116,6 @@ public class TestOrder extends BaseTestInfo {
 	}
 
 	public void setDeviceType(DeviceType deviceType) {
-		this.deviceType = deviceType;
+		super.setDeviceType(deviceType);
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
@@ -12,9 +12,8 @@ import javax.persistence.Table;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.Type;
 
-import gov.cdc.usds.simplereport.db.model.AuditedEntity;
+import gov.cdc.usds.simplereport.db.model.BaseTestInfo;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
@@ -22,18 +21,12 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 @Entity
 @Table(name = "test_event")
 @Immutable
-public class NoJsonTestEvent extends AuditedEntity {
+public class NoJsonTestEvent extends BaseTestInfo {
 
 	@Column
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
 	private TestResult result;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "organization_id")
-	private Organization organization;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "patient_id")
-	private Person patient;
 	@ManyToOne
 	@JoinColumn(name = "device_type_id")
 	private DeviceType deviceType;
@@ -44,14 +37,6 @@ public class NoJsonTestEvent extends AuditedEntity {
 
 	public TestResult getResult() {
 		return result;
-	}
-
-	public Organization getOrganization() {
-		return organization;
-	}
-
-	public Person getPatient() {
-		return patient;
 	}
 
 	public DeviceType getDeviceType() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
@@ -1,47 +1,27 @@
 package gov.cdc.usds.simplereport.db.model.readonly;
 
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.Immutable;
-import org.hibernate.annotations.Type;
 
 import gov.cdc.usds.simplereport.db.model.BaseTestInfo;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
-import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @Entity
 @Table(name = "test_event")
 @Immutable
+@AttributeOverride(name = "result", column = @Column(nullable = false))
 public class NoJsonTestEvent extends BaseTestInfo {
 
-	@Column
-	@Type(type = "pg_enum")
-	@Enumerated(EnumType.STRING)
-	private TestResult result;
-	@ManyToOne
-	@JoinColumn(name = "device_type_id")
-	private DeviceType deviceType;
 	@OneToOne(mappedBy = "testEvent")
 	private NoJsonTestOrder order;
 
 	protected NoJsonTestEvent() { /* no-op */ }
-
-	public TestResult getResult() {
-		return result;
-	}
-
-	public DeviceType getDeviceType() {
-		return deviceType;
-	}
 
 	public NoJsonTestOrder getTestOrder() {
 		return order;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestOrder.java
@@ -8,10 +8,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
-import javax.persistence.FetchType;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.Immutable;
@@ -19,7 +19,6 @@ import org.hibernate.annotations.Type;
 import org.json.JSONObject;
 
 import gov.cdc.usds.simplereport.db.model.BaseTestInfo;
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
 import gov.cdc.usds.simplereport.db.model.auxiliary.OrderStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
@@ -32,19 +31,12 @@ public class NoJsonTestOrder extends BaseTestInfo {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "patient_answers_id" )
 	private PatientAnswers askOnEntrySurvey;
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "device_type_id")
-	private DeviceType deviceType;
 	@Column
 	private LocalDate dateTested;
 	@Column(nullable = false)
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
 	private OrderStatus orderStatus;
-	@Column(nullable = true)
-	@Type(type = "pg_enum")
-	@Enumerated(EnumType.STRING)
-	private TestResult result;
 	@OneToOne(optional = true)
 	@JoinColumn(name="test_event_id")
 	private NoJsonTestEvent testEvent;
@@ -60,7 +52,7 @@ public class NoJsonTestOrder extends BaseTestInfo {
 	}
 
 	public TestResult getTestResult() {
-		return result;
+		return getResult();
 	}
 
 	public Date getDateAdded() {
@@ -69,10 +61,6 @@ public class NoJsonTestOrder extends BaseTestInfo {
 
 	public LocalDate getDateTested() {
 		return dateTested;
-	}
-
-	public DeviceType getDeviceType() {
-		return deviceType;
 	}
 
 	public NoJsonTestEvent getTestEvent() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestOrder.java
@@ -18,25 +18,17 @@ import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.Type;
 import org.json.JSONObject;
 
-import gov.cdc.usds.simplereport.db.model.AuditedEntity;
+import gov.cdc.usds.simplereport.db.model.BaseTestInfo;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.PatientAnswers;
-import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.auxiliary.OrderStatus;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 
 @Entity
 @Immutable
 @Table(name = "test_order")
-public class NoJsonTestOrder extends AuditedEntity {
+public class NoJsonTestOrder extends BaseTestInfo {
 
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "patient_id")
-	private Person patient;
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "organization_id")
-	private Organization organization;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "patient_answers_id" )
 	private PatientAnswers askOnEntrySurvey;
@@ -59,12 +51,6 @@ public class NoJsonTestOrder extends AuditedEntity {
 
 	protected NoJsonTestOrder() { /* for hibernate */ }
 
-	public Person getPatient() {
-		return patient;
-	}
-	public Organization getOrganization() {
-		return organization;
-	}
 	public OrderStatus getOrderStatus() {
 		return orderStatus;
 	}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestOrder.java
@@ -31,8 +31,6 @@ public class NoJsonTestOrder extends BaseTestInfo {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "patient_answers_id" )
 	private PatientAnswers askOnEntrySurvey;
-	@Column
-	private LocalDate dateTested;
 	@Column(nullable = false)
 	@Type(type = "pg_enum")
 	@Enumerated(EnumType.STRING)
@@ -57,10 +55,6 @@ public class NoJsonTestOrder extends BaseTestInfo {
 
 	public Date getDateAdded() {
 		return getCreatedAt();
-	}
-
-	public LocalDate getDateTested() {
-		return dateTested;
 	}
 
 	public NoJsonTestEvent getTestEvent() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -105,7 +105,7 @@ public class TestOrderService {
     if (existingOrder.isPresent()) {
       throw new IllegalGraphqlArgumentException("Cannot create multiple queue entries for the same patient");
     }
-    TestOrder newOrder = new TestOrder(patient, _os.getCurrentOrganization());
+    TestOrder newOrder = new TestOrder(patient);
 
     AskOnEntrySurvey survey = new AskOnEntrySurvey(
       pregnancy,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -43,9 +43,9 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 	@Test
 	public void runChanges() {
 		Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
-
-		Organization gwu = _orgRepo.save(new Organization("George Washington", "gwu", "55555", null, mccoy));
-		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt", "66666", null, mccoy));
+		DeviceType dt = _dataFactory.getGenericDevice();
+		Organization gwu = _orgRepo.save(new Organization("George Washington", "gwu", "55555", dt, mccoy));
+		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt", "66666", dt, mccoy));
 		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", null, LocalDate.now(), null, "(123) 456-7890", PersonRole.RESIDENT, "", null, "", "", false, false));
 		TestOrder order = _repo.save(new TestOrder(hoya));
 		List<TestOrder> queue = _repo.fetchQueueForOrganization(gwu);
@@ -62,7 +62,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 	public void testLifeCycle() {
 		Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
 		DeviceType device = _dataFactory.getGenericDevice();
-		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt", "77777", null, mccoy));
+		Organization gtown = _orgRepo.save(new Organization("Georgetown", "gt", "77777", device, mccoy));
 		Person hoya = _personRepo.save(new Person(gtown, "lookupId", "Joe", null, "Schmoe", null, LocalDate.now(), null, "(123) 456-7890", PersonRole.RESIDENT, "", null, "", "", false, false));
 		TestOrder order = _repo.save(new TestOrder(hoya));
 		flush();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -20,6 +20,7 @@ import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 @Component
 public class TestDataFactory {
 
+	private static final String DEFAULT_DEVICE_TYPE = "Acme SuperFine";
 	@Autowired
 	private OrganizationRepository _orgRepo;
 	@Autowired
@@ -30,7 +31,7 @@ public class TestDataFactory {
 	private DeviceTypeRepository _deviceRepo;
 
 	public Organization createValidOrg() {
-		DeviceType dev = _deviceRepo.save(new DeviceType("Acme SuperFine", "Acme", "SFN", "54321-BOOM"));
+		DeviceType dev = getGenericDevice();
 		StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
 		Provider doc = _providerRepo.save(new Provider("Doctor", "", "Doom", "", "DOOOOOOM", addy, "1-900-CALL-FOR-DOC")); 
 		return _orgRepo.save(new Organization("The Mall", "MALLRAT", "123456", dev, doc));
@@ -48,5 +49,10 @@ public class TestDataFactory {
 			"W", null, "M", false, false
 		);
 		return _personRepo.save(p);
+	}
+
+	public DeviceType getGenericDevice() {
+		return _deviceRepo.findAll().stream().filter(d->d.getName().equals(DEFAULT_DEVICE_TYPE)).findFirst()
+			.orElseGet(()->_deviceRepo.save(new DeviceType(DEFAULT_DEVICE_TYPE, "Acme", "SFN", "54321-BOOM")));
 	}
 }


### PR DESCRIPTION
As prep work for introducing Facilities (no, honestly, that's why), pulled a bunch of common fields or to-be-common fields into base classes.

* Person (and the upcoming Facility) is an EternalEntity that has a mandatory immutable Organization field: pulled that into `OrganizationScopedEnternalEntity`
* TestOrder, TestEvent, and their NoJson doppelgängers have four common fields: patient, organization, deviceType, and result. These are pulled up into `BaseTestInfo` (rename suggestions welcome)
   * the `result` column is nullable in some cases but not in others: this is handled using an `@AttributeOverride`, which is a neat trick that I just discovered because I was sure it must exist
   * the `deviceType` foreign key relationship was previously optional in TestOrder, but per #75 and CDCGov/prime-central#151 it seems like it should be mandatory, so I did the first step suggested in #75 and made it mandatory.

As a consequence of that last bullet, organizations with no default device type will now be unable to create queue entries. That is not necessarily bad, but means we should potentially be more careful about making sure that the default device type is never accidentally cleared...