### PR TITLE
Fix 404 on Okta logout

### DIFF
--- a/frontend/src/app/commonComponents/Header.jsx
+++ b/frontend/src/app/commonComponents/Header.jsx
@@ -55,10 +55,14 @@ const Header = ({ organizationId }) => {
   };
 
   const logout = () => {
-    const id_token = whoamidata.whoami.id;
+    // Fetch the id_token from local storage
+    const id_token = localStorage.getItem("id_token");
     const state = uuidv4();
+    // Remove auth data from local_storage
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("id_token");
     window.location.replace(
-      `https://hhs-prime.okta.com/logout?id_token_hint=${id_token}&post_logout_redirect_uri=https://simplereport.cdc.gov&state=${state}`
+      `https://hhs-prime.okta.com/oauth2/default/v1/logout?id_token_hint=${id_token}&post_logout_redirect_uri=https://simplereport.cdc.gov&state=${state}`
     );
   };
   return (
@@ -145,7 +149,7 @@ const Header = ({ organizationId }) => {
                   {staffName}
                 </li>
                 <li className="usa-sidenav__item">{facilityName}</li>
-                <li className="usa-sidenav__item" style={{ display: "none" }}>
+                <li className="usa-sidenav__item">
                   <Anchor text="Log out" onClick={() => logout()} />
                 </li>
               </ul>
@@ -198,7 +202,7 @@ const Header = ({ organizationId }) => {
                     {staffName}
                   </li>
                   <li className="usa-sidenav__item">{facilityName}</li>
-                  <li className="usa-sidenav__item" style={{ display: "none" }}>
+                  <li className="usa-sidenav__item">
                     <Anchor text={" Log out"} onClick={() => logout()} />
                   </li>
                 </ul>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -27,9 +27,9 @@ if (window.location.hash) {
     localStorage.setItem("access_token", bearerToken);
   }
   // We need to store the ID token in order for logout to work correctly.
-  const idToken = params.get("id_token")
+  const idToken = params.get("id_token");
   if (idToken) {
-    localStorage.setItem("id_token", idToken)
+    localStorage.setItem("id_token", idToken);
   }
 }
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -26,6 +26,11 @@ if (window.location.hash) {
   if (bearerToken) {
     localStorage.setItem("access_token", bearerToken);
   }
+  // We need to store the ID token in order for logout to work correctly.
+  const idToken = params.get("id_token")
+  if (idToken) {
+    localStorage.setItem("id_token", idToken)
+  }
 }
 
 const httpLink = new HttpLink({ uri: process.env.REACT_APP_BACKEND_URL });


### PR DESCRIPTION
Addressed 2 issues in the code that popped up from #216.

1. The Okta logout URL was incorrect, we needed to point to the default authorization server.
My fault on sending along bad info.

2. We need to pass in the id_token along with the request.
Modified the index file to capture the id token alongside the access token and store both in local storage.

On logout, we fetch the id_token from localstorage and send it along.
We also remove the tokens from localStorage before doing the Okta redirect.

Created https://github.com/CDCgov/SimpleReport_Public_Site/pull/29 to update the static site to request the id_token as part of the redirect url.