### PR TITLE
Revamped cloud.gov deploys to have a working integration environment.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,13 @@
 name: Deploy Client Application
 
 env:
-  DEMO_CF_APP: "prime-data-input-client" # the app name if we are deploying 'main'
-  SANDBOX_CF_APP: "prime-data-input-sandbox" # the app name if we are deploying any other branch
+  DEMO_CF_APP: "simple-report-qa" # the app name if we are deploying 'main'
+  SANDBOX_CF_APP: "simple-report-sandbox" # the app name if we are deploying any other branch
   NODE_VERSION: 14
 on:
   workflow_dispatch: # run when somebody pushes the button (on whatever branch they choose)
   push:
-    branches: # automatically deploy the "sandbox" branch on every push
+    branches: # automatically deploy the "sandbox" and "main" branches to their respective envs
       - sandbox
       - main
   schedule:
@@ -24,7 +24,7 @@ jobs:
           if  [[ "$GITHUB_REF" == "refs/heads/main" ]] ; then
             echo We are deploying to the DEMO environment
             app=$DEMO_CF_APP
-            title="SimpleReport"
+            title="SimpleReportQA"
           else
             echo We are deploying to the SANDBOX environment
             app=$SANDBOX_CF_APP

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           path: |
             ~/.npm
             ./frontend/node_modules
-          key: npm-build-${{env.NODE_VERSION}-${{ hashFiles('client/package-lock.json', 'client/package.json') }}
+          key: npm-build-${{env.NODE_VERSION}}-${{ hashFiles('client/package-lock.json', 'client/package.json') }}
       - name: Node setup
         working-directory: ./frontend
         run: npm install

--- a/.github/workflows/restage.yml
+++ b/.github/workflows/restage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy-to:
-        description: Which instance should we restage ("client" or "sandbox" or "sandbox-backend")?
+        description: Which instance should we restage ("qa" or "sandbox" or "qa-api")?
         default: sandbox
 jobs:
   restage:
@@ -16,5 +16,5 @@ jobs:
           org: ${{secrets.CLOUD_GOV_ORG}}
           user: ${{secrets.SERVICE_USER}}
           password: ${{secrets.SERVICE_PASSWORD}}
-          application: prime-data-input-${{github.event.inputs.deploy-to}}
+          application: simple-report-${{github.event.inputs.deploy-to}}
           command: restage

--- a/backend/manifest.yml
+++ b/backend/manifest.yml
@@ -1,5 +1,5 @@
 applications:
-- name: prime-data-input-sandbox-backend
+- name: simple-report-qa-api
   path: ./build/libs/simple-report-0.0.1-SNAPSHOT.jar
   disk_quota: 1G
   instances: 1

--- a/backend/manifest.yml
+++ b/backend/manifest.yml
@@ -7,3 +7,5 @@ applications:
   stack: cflinuxfs3
   services:
     - prime-simplereport-db
+  env:
+    JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ }}'

--- a/backend/src/main/resources/application-cloud.yaml
+++ b/backend/src/main/resources/application-cloud.yaml
@@ -1,3 +1,14 @@
+spring:
+  profiles.include: no-security
+  jpa:
+    properties:
+      hibernate:
+        default_schema: simple_report
+graphql.servlet.cors:
+  allowed-origins:
+    - http://localhost:3000
+    - https://simple-report-qa.app.cloud.gov
+    - https://simple-report-sandbox.app.cloud.gov
 simple-report-initialization:
   organization:
     facility-name: Dis Organization

--- a/backend/src/main/resources/application-cloud.yaml
+++ b/backend/src/main/resources/application-cloud.yaml
@@ -1,4 +1,5 @@
 spring:
+  profiles.include: no-security
   jpa:
     properties:
       hibernate:
@@ -6,7 +7,5 @@ spring:
 graphql.servlet.cors:
   allowed-origins:
     - http://localhost:3000
-    - https://prime-data-input-client.app.cloud.gov
-    - https://prime-data-input-sandbox.app.cloud.gov
-    - https://simple-report.app.cloud.gov
+    - https://simple-report-qa.app.cloud.gov
     - https://simple-report-sandbox.app.cloud.gov

--- a/backend/src/main/resources/application-cloud.yaml
+++ b/backend/src/main/resources/application-cloud.yaml
@@ -1,11 +1,18 @@
-spring:
-  profiles.include: no-security
-  jpa:
-    properties:
-      hibernate:
-        default_schema: simple_report
-graphql.servlet.cors:
-  allowed-origins:
-    - http://localhost:3000
-    - https://simple-report-qa.app.cloud.gov
-    - https://simple-report-sandbox.app.cloud.gov
+simple-report-initialization:
+  organization:
+    facility-name: Dis Organization
+    external-id: DIS_ORG
+    clia-number: "000111222-3"
+  provider:
+    first-name: Fred
+    last-name: Flintstone
+    provider-id: PEBBLES
+    telephone: (202) 555-1212
+    address:
+      street-1: 123 Main Street
+      city: Oz
+      state: KS
+      zip-code: "12345"
+  configured-device-types:
+    - LumiraDX
+    - Quidel Sofia 2

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,5 +1,5 @@
 REACT_APP_TITLE=SimpleReport
-REACT_APP_DESCRIPTION=SimpleReport Test Management Prototype Application
+REACT_APP_DESCRIPTION=SimpleReport Test Management Application
 REACT_APP_ICON=usds-32x32.png
-REACT_APP_BACKEND_URL=https://prime-data-input-sandbox-backend.app.cloud.gov/graphql
+REACT_APP_BACKEND_URL=https://simple-report-qa-api.app.cloud.gov/graphql
 REACT_APP_OKTA_URL=https://simplereport.cdc.gov/

--- a/frontend/manifest.yml
+++ b/frontend/manifest.yml
@@ -1,27 +1,13 @@
 applications:
-  - name: prime-data-input-client
+  - name: simple-report-qa
     memory: 32M
     pushstate: enabled
     path: build/ # specify where the app is located. The frontend gets built and deployed alongside the backend
     buildpacks:
       - https://github.com/cloudfoundry/staticfile-buildpack
-    routes:
-      - route: prime-data-input-client.app.cloud.gov
-      - route: simple-report.app.cloud.gov
-  - name: prime-data-input-sandbox
+  - name: simple-report-sandbox
     memory: 32M
     pushstate: enabled
     path: build/ # specify where the app is located. The frontend gets built and deployed alongside the backend
     buildpacks:
       - https://github.com/cloudfoundry/staticfile-buildpack
-    routes:
-      - route: prime-data-input-sandbox.app.cloud.gov
-      - route: simple-report-sandbox.app.cloud.gov
-  - name: prime-data-input-training
-    memory: 32M
-    pushstate: enabled
-    path: build/ # specify where the app is located. The frontend gets built and deployed alongside the backend
-    buildpacks:
-      - https://github.com/cloudfoundry/staticfile-buildpack
-    routes:
-      - route: simple-report-training.app.cloud.gov


### PR DESCRIPTION
Made simple-report-qa and simple-report-sandbox separate front-end instances hitting the same API instance, turned off authentication for that instance, and eliminated wiring for other names and instances.

PR against the previous workflow branch because otherwise terrible conflicts ensue.