### PR TITLE
API tests and errors

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java
@@ -28,7 +28,6 @@ public class Organization extends EternalEntity {
 	private String externalId;
 
 	@Column(nullable=false)
-	@NaturalId
 	private String cliaNumber;
 
 	@ManyToOne(optional = true)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PersonRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/PersonRepository.java
@@ -5,6 +5,7 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -16,5 +17,5 @@ public interface PersonRepository extends EternalEntityRepository<Person> {
     public List<Person> findAllByOrganization(Organization org);
 
     @Query(BASE_QUERY + " and internalId = :id and organization = :org")
-    public Person findByIDAndOrganization(UUID id, Organization org);
+    public Optional<Person> findByIDAndOrganization(UUID id, Organization org);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/PersonService.java
@@ -8,6 +8,8 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
@@ -33,8 +35,13 @@ public class PersonService {
 
 
 	public Person getPatient(String id) {
+		return getPatient(id, _os.getCurrentOrganization());
+	}
+
+	public Person getPatient(String id, Organization org) {
 		UUID actualId = UUID.fromString(id);
-		return _repo.findByIDAndOrganization(actualId,_os.getCurrentOrganization());
+		return _repo.findByIDAndOrganization(actualId, org)
+			.orElseThrow(()->new IllegalGraphqlArgumentException("No patient with that ID was found"));
 	}
 
 	public String addPatient(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +33,10 @@ public class OrganizationFacilityTest extends BaseApiTest {
 		assertEquals("000111222-3", facNode.get("cliaNumber").asText());
 		assertEquals("2797 N Cerrada de Beto", facNode.get("street").asText()); // oh my
 		ArrayNode typeList = (ArrayNode) orgNode.get("deviceTypes");
-		assertEquals("Quidel Sofia 2", typeList.get(0).get("name").asText()); // hope this is deterministic...
-		assertEquals("LumiraDX", typeList.get(1).get("name").asText());
+		Set<String> deviceNames = new HashSet<>();
+		typeList.iterator().forEachRemaining(t->deviceNames.add(t.get("name").asText()));
+		assertTrue(deviceNames.contains("Quidel Sofia 2"), "should find Quidel Sofia 2 in " + typeList.toString());
+		assertTrue(deviceNames.contains("LumiraDX"), "should find LumiraDX in " + typeList.toString());
 
 	}
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
@@ -1,0 +1,39 @@
+package gov.cdc.usds.simplereport.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class OrganizationFacilityTest extends BaseApiTest {
+
+	@BeforeEach
+	public void setup() {
+		truncateDb();
+	}
+
+	@Test
+	public void fetchFakeOrgData() {
+		ObjectNode resp = runQuery("org-settings-query");
+		ObjectNode orgNode = (ObjectNode) resp.get("organization");
+		JsonNode facNode = orgNode.path("testingFacility");
+		assertTrue(facNode.isObject(), "facility should be an object in response");
+		assertEquals("Dis Organization", facNode.get("name").asText());
+		assertEquals("000111222-3", facNode.get("cliaNumber").asText());
+		assertEquals("2797 N Cerrada de Beto", facNode.get("street").asText()); // oh my
+	}
+
+	@Test
+	public void fetchFakeUserData() {
+		ObjectNode resp = runQuery("current-user-query");
+		ObjectNode who = (ObjectNode) resp.get("whoami");
+		assertEquals("Bobbity", who.get("firstName").asText());
+		ObjectNode facNode = (ObjectNode) who.get("organization").get("testingFacility");
+		assertEquals("Dis Organization", facNode.get("name").asText());
+	}
+
+}

--- a/backend/src/test/resources/current-user-query
+++ b/backend/src/test/resources/current-user-query
@@ -1,0 +1,17 @@
+{
+  whoami {
+    id
+    firstName
+    middleName
+    lastName
+    suffix
+    organization {
+      testingFacility {
+        name
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}

--- a/backend/src/test/resources/org-settings-query
+++ b/backend/src/test/resources/org-settings-query
@@ -30,17 +30,14 @@
     }
     defaultDeviceType {
       internalId
+      name
       __typename
     }
     deviceTypes {
       internalId
+      name
       __typename
     }
-    __typename
-  }
-  deviceType {
-    internalId
-    name
     __typename
   }
 }

--- a/backend/src/test/resources/org-settings-query
+++ b/backend/src/test/resources/org-settings-query
@@ -1,0 +1,46 @@
+{
+  organization {
+    internalId
+    testingFacility {
+      cliaNumber
+      name
+      street
+      streetTwo
+      city
+      county
+      state
+      zipCode
+      phone
+      __typename
+    }
+    orderingProvider {
+      firstName
+      middleName
+      lastName
+      suffix
+      NPI
+      street
+      streetTwo
+      city
+      county
+      state
+      zipCode
+      phone
+      __typename
+    }
+    defaultDeviceType {
+      internalId
+      __typename
+    }
+    deviceTypes {
+      internalId
+      __typename
+    }
+    __typename
+  }
+  deviceType {
+    internalId
+    name
+    __typename
+  }
+}

--- a/backend/src/test/resources/update-org-settings
+++ b/backend/src/test/resources/update-org-settings
@@ -1,0 +1,18 @@
+mutation doUpdate($newDevice: String!) {
+  updateOrganization(
+    testingFacilityName: "Dis Function"
+    cliaNumber: "54321"
+    orderingProviderFirstName: "John"
+    orderingProviderMiddleName: "The"
+    orderingProviderLastName: "Doctor"
+    orderingProviderNPI: "ABCDE"
+    orderingProviderStreet: "111 Massachusetts Avenue"
+    orderingProviderCity: "Washington"
+    orderingProviderCounty: "N/A"
+    orderingProviderState: "DC"
+    orderingProviderZipCode: "20001"
+    deviceTypes: [$newDevice]
+    defaultDevice: $newDevice
+  )
+    
+}


### PR DESCRIPTION
Added basic tests for the "whoami" endpoint and the organization settings round trip.

Also added some explicit exceptions for attempts to edit or enqueue nonexistent patients, or double-dequeue patients.