### PR TITLE
Persistence layer support for multiple facilities 

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiFacility.java
@@ -1,13 +1,14 @@
 package gov.cdc.usds.simplereport.api.model;
 
-import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Facility;
 
 public class ApiFacility {
-	private Organization org;
 
-	public ApiFacility(Organization org) {
+	private Facility org;
+
+	public ApiFacility(Facility wrapped) {
 		super();
-		this.org = org;
+		this.org = wrapped;
 	}
 
 	public String getName() {
@@ -16,33 +17,33 @@ public class ApiFacility {
 
 	public String getCliaNumber() {
 		return org.getCliaNumber();
-  }
+    }
   
-  public String getStreet() {
-		return "2797 N Cerrada de Beto";
+    public String getStreet() {
+		return org.getAddress().getStreetOne();
 	}
 
 	public String getStreetTwo() {
-		return "";
+		return org.getAddress().getStreetTwo();
 	}
 
 	public String getCity() {
-		return "Tucson";
+		return org.getAddress().getCity();
 	}
 
 	public String getCounty() {
-    return "Pima";
+    return org.getAddress().getCounty();
 	}
 
 	public String getState() {
-		return "AZ";
+		return org.getAddress().getState();
 	}
 
 	public String getZipCode() {
-		return "85745";
+		return org.getAddress().getPostalCode();
 	}
 
 	public String getPhone() {
-		return "5202475313";
+		return org.getTelephone();
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiOrganization.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiOrganization.java
@@ -1,8 +1,5 @@
 package gov.cdc.usds.simplereport.api.model;
 
-import java.util.List;
-
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
 
 public class ApiOrganization {
@@ -17,22 +14,4 @@ public class ApiOrganization {
 		return org.getInternalId().toString();
 	}
 
-	public ApiFacility getTestingFacility() {
-		return new ApiFacility(org);
-	}
-
-	public ApiProvider getOrderingProvider() {
-		if (org.getOrderingProvider() == null) {
-			return null;
-		}
-		return new ApiProvider(org.getOrderingProvider());
-	}
-
-	public List<DeviceType> getDeviceTypes() {
-		return org.getDeviceTypes();
-	}
-
-	public DeviceType getDefaultDeviceType() {
-		return org.getDefaultDeviceType();
-	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/TestEventExport.java
@@ -4,28 +4,24 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestEvent;
-import gov.cdc.usds.simplereport.db.model.readonly.NoJsonTestOrder;
 
 public class TestEventExport {
 
 	private NoJsonTestEvent testEvent;
-	private NoJsonTestOrder testOrder;
 	private Person patient;
 	private AskOnEntrySurvey survey;
 	private Provider provider;
-	private Organization org;
+	private Facility facility;
 
 	public TestEventExport(NoJsonTestEvent testEvent) {
 		super();
@@ -33,7 +29,7 @@ public class TestEventExport {
 		this.patient = testEvent.getPatientData();
 		this.survey = testEvent.getTestOrder().getAskOnEntrySurvey().getSurvey();
 		this.provider = testEvent.getProviderData();
-		this.org = testEvent.getOrganization();
+		this.facility = testEvent.getFacility();
 	}
 
 	// values pulled from https://github.com/CDCgov/prime-data-hub/blob/master/prime-router/metadata/valuesets/common.valuesets
@@ -73,18 +69,6 @@ public class TestEventExport {
 		} else {
 			return "N";
 		}
-	}
-
-	private String arrayToString(List<String> value) {
-		if (value == null) {
-			return "";
-		}
-		if (value.size() < 1) {
-			return "";
-		}
-		return String.join(",", value.stream()
-		.map(v -> raceMap.get(v))
-		.collect(Collectors.toList()));
 	}
 
 	private String dateToHealthCareString(LocalDate value) {
@@ -254,7 +238,7 @@ public class TestEventExport {
 
 	@JsonProperty("Testing_lab_CLIA")
 	public String getTestingLabID() {
-		return org.getCliaNumber();
+		return facility.getCliaNumber();
 	}
 
 	@JsonProperty("Testing_lab_state")
@@ -304,32 +288,32 @@ public class TestEventExport {
 
 	@JsonProperty("Ordering_facility_name")
 	public String getOrderingFacilityName() {
-		return org.getFacilityName();
+		return facility.getFacilityName();
 	}
 
 	@JsonProperty("Ordering_facility_phone_number")
 	public String getOrderingFacilityPhoneNumber() {
-		return "5202475313";
+		return facility.getTelephone();
 	}
 
 	@JsonProperty("Ordering_facility_state")
 	public String getOrderingFacilityState() {
-		return "AZ";
+		return facility.getAddress().getState();
 	}
 
 	@JsonProperty("Ordering_facility_street")
 	public String getOrderingFacilityStreet() {
-		return "2797 N Cerrada de Beto";
+		return facility.getAddress().getStreetOne();
 	}
 
 	@JsonProperty("Ordering_facility_street_2")
 	public String getOrderingFacilityStreetTwo() {
-		return "";
+		return facility.getAddress().getStreetTwo();
 	}
 
 	@JsonProperty("Ordering_facility_zip_code")
 	public String getOrderingFacilityZipCode() {
-		return "85745";
+		return facility.getAddress().getPostalCode();
 	}
 
 	@JsonProperty("Ordering_provider_last_name")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationDataResolver.java
@@ -1,0 +1,51 @@
+package gov.cdc.usds.simplereport.api.organization;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import gov.cdc.usds.simplereport.api.model.ApiFacility;
+import gov.cdc.usds.simplereport.api.model.ApiOrganization;
+import gov.cdc.usds.simplereport.api.model.ApiProvider;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.service.OrganizationService;
+import graphql.kickstart.tools.GraphQLResolver;
+
+@Service
+public class OrganizationDataResolver implements GraphQLResolver<ApiOrganization> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrganizationDataResolver.class);
+
+	@Autowired
+	private OrganizationService _orgService;
+
+	public ApiFacility getTestingFacility(ApiOrganization o) {
+		LOG.error("Asked me for a facility for {}", o);
+		return new ApiFacility(getCurrentFacility());
+	}
+
+	public ApiProvider getOrderingProvider(ApiOrganization o) {
+		LOG.error("Asked me for a provider for {}", o);
+		return new ApiProvider(getCurrentFacility().getOrderingProvider());
+	}
+
+	private Facility getCurrentFacility() {
+		Organization org = _orgService.getCurrentOrganization();
+		return _orgService.getDefaultFacility(org);
+	}
+
+	public List<DeviceType> getDeviceTypes(ApiOrganization o) {
+		LOG.error("Asked me for device types for {}", o);
+		return getCurrentFacility().getDeviceTypes();
+	}
+
+	public DeviceType getDefaultDeviceType(ApiOrganization o) {
+		LOG.error("Asked me for default device type for {}", o);
+		return getCurrentFacility().getDefaultDeviceType();
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/organization/OrganizationDataResolver.java
@@ -2,8 +2,6 @@ package gov.cdc.usds.simplereport.api.organization;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -16,21 +14,22 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import graphql.kickstart.tools.GraphQLResolver;
 
+/**
+ * GraphQL resolver for fields of the Organization API model that are no longer fields
+ * of the Organization database model. Most of the original content should probably be
+ * removed before Christmas 2020.
+ */
 @Service
 public class OrganizationDataResolver implements GraphQLResolver<ApiOrganization> {
-
-	private static final Logger LOG = LoggerFactory.getLogger(OrganizationDataResolver.class);
 
 	@Autowired
 	private OrganizationService _orgService;
 
 	public ApiFacility getTestingFacility(ApiOrganization o) {
-		LOG.error("Asked me for a facility for {}", o);
 		return new ApiFacility(getCurrentFacility());
 	}
 
 	public ApiProvider getOrderingProvider(ApiOrganization o) {
-		LOG.error("Asked me for a provider for {}", o);
 		return new ApiProvider(getCurrentFacility().getOrderingProvider());
 	}
 
@@ -40,12 +39,10 @@ public class OrganizationDataResolver implements GraphQLResolver<ApiOrganization
 	}
 
 	public List<DeviceType> getDeviceTypes(ApiOrganization o) {
-		LOG.error("Asked me for device types for {}", o);
 		return getCurrentFacility().getDeviceTypes();
 	}
 
 	public DeviceType getDefaultDeviceType(ApiOrganization o) {
-		LOG.error("Asked me for default device type for {}", o);
 		return getCurrentFacility().getDefaultDeviceType();
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/InitialSetupProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
@@ -18,18 +19,28 @@ import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 public class InitialSetupProperties {
 
 	private Organization organization;
-	private ConfigProvider provider;
-	private List<? extends ConfigDeviceType> deviceTypes;
+	private Provider provider;
+	private List<? extends DeviceType> deviceTypes;
 	private List<String> configuredDeviceTypes;
 	private IdentityAttributes defaultUser;
+	private ConfigFacility facility;
 
-	public InitialSetupProperties(ConfigOrganization organization, ConfigProvider provider,
-			List<ConfigDeviceType> deviceTypes, List<String> configuredDeviceTypes, IdentityAttributes defaultUser) {
+	public InitialSetupProperties(Organization organization,
+			ConfigFacility facility,
+			Provider provider,
+			List<DeviceType> deviceTypes,
+			List<String> configuredDeviceTypes,
+			IdentityAttributes defaultUser) {
 		this.organization = organization;
 		this.provider = provider;
 		this.deviceTypes = deviceTypes;
 		this.configuredDeviceTypes = configuredDeviceTypes;
 		this.defaultUser = defaultUser;
+		this.facility = facility;
+	}
+
+	public ConfigFacility getFacility() {
+		return facility;
 	}
 
 	public List<String> getConfiguredDeviceTypeNames() {
@@ -37,47 +48,57 @@ public class InitialSetupProperties {
 	}
 
 	public Organization getOrganization() {
-		return organization;
+		return new Organization(organization.getOrganizationName(), organization.getExternalId());
 	}
 
 	public Provider getProvider() {
-		return provider.getRealProvider();
+		PersonName n = provider.getNameInfo();
+		return new Provider(n.getFirstName(), n.getMiddleName(), n.getLastName(), n.getSuffix(),
+			provider.getProviderId(), provider.getAddress(), provider.getTelephone());
 	}
 
 	public List<? extends DeviceType> getDeviceTypes() {
-		return deviceTypes.stream().map(ConfigDeviceType::getReal).collect(Collectors.toList());
+		return deviceTypes.stream()
+			.map(d->new DeviceType(d.getName(), d.getManufacturer(), d.getModel(), d.getLoincCode()))
+			.collect(Collectors.toList())
+			;
 	}
 
 	public IdentityAttributes getDefaultUser() {
 		return defaultUser;
 	}
 
-	private static final class ConfigOrganization extends Organization {
-		@ConstructorBinding
-		public ConfigOrganization(String facilityName, String externalId, String cliaNumber) {
-			super(facilityName, externalId, cliaNumber);
+	public static final class ConfigFacility {
+		private String name;
+		private String cliaNumber;
+		private StreetAddress address;
+		private String telephone;
+		public ConfigFacility(String facilityName, String cliaNumber, StreetAddress address, String telephone) {
+			super();
+			this.name = facilityName;
+			this.cliaNumber = cliaNumber;
+			this.address = address;
+			this.telephone = telephone;
 		}
-	}
-	public static final class ConfigProvider extends Provider {
-		@ConstructorBinding
-		public ConfigProvider(String firstName, String middleName, String lastName, String suffix, String providerId,
-				StreetAddress address, String telephone) {
-			super(firstName, middleName, lastName, suffix, providerId, address, telephone);
-		}
-		public Provider getRealProvider() {
-			PersonName nm = getNameInfo();
-			return new Provider(nm.getFirstName(), nm.getMiddleName(), nm.getLastName(), nm.getSuffix(),
-				getProviderId(), getAddress(), getTelephone());
-		}
-	}
 
-	private static final class ConfigDeviceType extends DeviceType {
-		@ConstructorBinding
-		public ConfigDeviceType(String name, String manufacturer, String model, String loincCode) {
-			super(name, manufacturer, model, loincCode);
+		public Facility makeRealFacility(Organization org, Provider p, DeviceType defaultDeviceType, List<DeviceType> configured) {
+			Facility f = new Facility(org, name, cliaNumber, p, defaultDeviceType, configured);
+			f.setAddress(address);
+			f.setTelephone(telephone);
+			return f;
 		}
-		public DeviceType getReal() {
-			return new DeviceType(getName(), getManufacturer(), getModel(), getLoincCode());
+
+		public String getName() {
+			return name;
+		}
+		public String getCliaNumber() {
+			return cliaNumber;
+		}
+		public StreetAddress getAddress() {
+			return address;
+		}
+		public String getTelephone() {
+			return telephone;
 		}
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/BaseTestInfo.java
@@ -24,6 +24,10 @@ public abstract class BaseTestInfo extends AuditedEntity
 	private Organization organization;
 
 	@ManyToOne(optional = false)
+	@JoinColumn(name = "facility_id", updatable = false)
+	private Facility facility;
+
+	@ManyToOne(optional = false)
 	@JoinColumn(name = "device_type_id")
 	private DeviceType deviceType;
 
@@ -36,16 +40,17 @@ public abstract class BaseTestInfo extends AuditedEntity
 		super();
 	}
 
-	public BaseTestInfo(Person patient, Organization organization, DeviceType deviceType, TestResult result) {
+	public BaseTestInfo(Person patient, Facility facility, DeviceType deviceType, TestResult result) {
 		super();
 		this.patient = patient;
-		this.organization = organization;
+		this.facility = facility;
+		this.organization = facility.getOrganization();
 		this.deviceType = deviceType;
 		this.result = result;
 	}
 
-	protected BaseTestInfo(Person patient) {
-		this(patient, patient.getOrganization(), patient.getOrganization().getDefaultDeviceType(), null);
+	protected BaseTestInfo(Person patient, Facility facility) {
+		this(patient, facility, facility.getDefaultDeviceType(), null);
 	}
 
 	public Person getPatient() {
@@ -55,6 +60,10 @@ public abstract class BaseTestInfo extends AuditedEntity
 	@Override
 	public Organization getOrganization() {
 		return organization;
+	}
+
+	public Facility getFacility() {
+		return facility;
 	}
 
 	public DeviceType getDeviceType() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
@@ -3,6 +3,8 @@ package gov.cdc.usds.simplereport.db.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
+import org.springframework.boot.context.properties.ConstructorBinding;
+
 /**
  * The durable (and non-deletable) representation of a POC test device model.
  */
@@ -20,6 +22,7 @@ public class DeviceType extends EternalEntity {
 
 	protected DeviceType() { /* no-op for hibernate */ }
 
+	@ConstructorBinding
 	public DeviceType(String name, String manufacturer, String model, String loincCode) {
 		super();
 		this.name = name;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -1,0 +1,153 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+@Entity
+public class Facility extends OrganizationScopedEternalEntity {
+
+	@Column(nullable = false, unique = false) // unique within an organization only
+	private String facilityName;
+
+	// these are common to all the children of the immediate base class, but ...
+	@Embedded
+	private StreetAddress address;
+	@Column
+	private String telephone;
+
+	@Column
+	private String cliaNumber;
+
+	@ManyToOne(optional = true)
+	@JoinColumn(name = "default_device_type_id")
+	private DeviceType defaultDeviceType;
+
+	@OneToOne(optional=false)
+	@JoinColumn(name = "ordering_provider_id", nullable = false)
+	private Provider orderingProvider;
+
+	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(
+		name = "facility_device_type",
+		joinColumns = @JoinColumn(name="facility_id"),
+		inverseJoinColumns = @JoinColumn(name="device_type_id")
+	)
+	private Set<DeviceType> configuredDevices = new HashSet<>();
+
+	protected Facility() {/* for hibernate */}
+
+	public Facility(Organization org, String facilityName, String cliaNumber, Provider orderingProvider) {
+		super(org);
+		this.facilityName = facilityName;
+		this.cliaNumber = cliaNumber;
+		this.orderingProvider = orderingProvider;
+	}
+
+	public Facility(Organization org,
+			String facilityName,
+			String cliaNumber,
+			Provider orderingProvider,
+			DeviceType defaultDeviceType) {
+		this(org, facilityName, cliaNumber, orderingProvider);
+		this.defaultDeviceType = defaultDeviceType;
+		if (defaultDeviceType != null) {
+			this.configuredDevices.add(defaultDeviceType);
+		}
+	}
+
+	public Facility(
+			Organization org,
+			String facilityName,
+			String cliaNumber,
+			Provider orderingProvider,
+			DeviceType defaultDeviceType,
+			Collection<DeviceType> configuredDevices) {
+		this(org, facilityName, cliaNumber, orderingProvider, defaultDeviceType);
+		this.configuredDevices.addAll(configuredDevices);
+	}
+
+	public void setFacilityName(String facilityName) {
+		this.facilityName = facilityName;
+	}
+
+	public String getFacilityName() {
+		return facilityName;
+	}
+
+	public DeviceType getDefaultDeviceType() {
+		return defaultDeviceType;
+	}
+
+	public void setDefaultDeviceType(DeviceType defaultDeviceType) {
+		this.defaultDeviceType = defaultDeviceType;
+	}
+
+	public List<DeviceType> getDeviceTypes() {
+		// this might be better done on the DB side, but that seems like a recipe for weird behaviors
+		return configuredDevices.stream()
+			.filter(e -> !e.isDeleted())
+			.collect(Collectors.toList());
+	}
+
+	public void addDeviceType(DeviceType newDevice) {
+		configuredDevices.add(newDevice);
+	}
+
+	public void addDefaultDeviceType(DeviceType newDevice) {
+		this.defaultDeviceType = newDevice;
+		addDeviceType(newDevice);
+	}
+
+	public void removeDeviceType(DeviceType existingDevice) {
+		configuredDevices.remove(existingDevice);
+		if (defaultDeviceType != null && existingDevice.getInternalId().equals(defaultDeviceType.getInternalId())) {
+			defaultDeviceType = null;
+		}
+	}
+
+	public String getCliaNumber() {
+		return this.cliaNumber;
+	}
+
+	public void setCliaNumber(String cliaNumber) {
+		this.cliaNumber = cliaNumber;
+	}
+
+	public Provider getOrderingProvider() {
+		return orderingProvider;
+	}
+
+	public void setOrderingProvider(Provider orderingProvider) {
+		this.orderingProvider = orderingProvider;
+	}
+
+	public StreetAddress getAddress() {
+		return address;
+	}
+
+
+	public void setAddress(StreetAddress address) {
+		this.address = address;
+	}
+
+	public String getTelephone() {
+		return telephone;
+	}
+
+	public void setTelephone(String telephone) {
+		this.telephone = telephone;
+	}
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java
@@ -1,132 +1,39 @@
 package gov.cdc.usds.simplereport.db.model;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 
 import org.hibernate.annotations.NaturalId;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Entity
 public class Organization extends EternalEntity {
 
 	@Column(nullable = false, unique = true)
-	private String facilityName;
+	private String organizationName;
 
 	@Column(name="organization_external_id", nullable=false, unique=true)
 	@NaturalId
 	private String externalId;
 
-	@Column(nullable=false)
-	private String cliaNumber;
-
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "default_device_type")
-	private DeviceType defaultDeviceType;
-
-	@OneToOne(optional=false)
-	@JoinColumn(name = "ordering_provider_id", nullable = false)
-	private Provider orderingProvider;
-
-	@ManyToMany(fetch = FetchType.EAGER)
-	@JoinTable(
-		name = "facility_device_type",
-		joinColumns = @JoinColumn(name="organization_id"),
-		inverseJoinColumns = @JoinColumn(name="device_type_id")
-	)
-	private Set<DeviceType> configuredDevices = new HashSet<>();
-
 	protected Organization() { /* for hibernate */ }
 
-	public Organization(String facilityName, String externalId, String cliaNumber) {
+	@ConstructorBinding
+	public Organization(String orgName, String externalId) {
 		this();
-		this.facilityName = facilityName;
+		this.organizationName = orgName;
 		this.externalId = externalId;
-		this.cliaNumber = cliaNumber;
 	}
 
-	public Organization(String facilityName, String externalId, String cliaNumber, DeviceType defaultDeviceType, Provider orderingProvider) {
-		this(facilityName, externalId, cliaNumber);
-		this.defaultDeviceType = defaultDeviceType;
-		if (defaultDeviceType != null) {
-			this.configuredDevices.add(defaultDeviceType);
-		}
-		this.orderingProvider = orderingProvider;
+	public String getOrganizationName() {
+		return organizationName;
 	}
 
-	public Organization(
-			String facilityName,
-			String externalId,
-			String cliaNumber,
-			DeviceType defaultDeviceType,
-			Provider orderingProvider,
-			Collection<DeviceType> configuredDevices) {
-		this(facilityName, externalId, cliaNumber, defaultDeviceType, orderingProvider);
-		this.configuredDevices.addAll(configuredDevices);
-	}
-
-	public void setFacilityName(String facilityName) {
-		this.facilityName = facilityName;
-	}
-
-	public String getFacilityName() {
-		return facilityName;
+	public void setOrganizatioName(String newName) {
+		organizationName = newName;
 	}
 
 	public String getExternalId() {
 		return externalId;
-	}
-
-	public void setCliaNumber(String cliaNumber) {
-		this.cliaNumber = cliaNumber;
-	}
-
-	public DeviceType getDefaultDeviceType() {
-		return defaultDeviceType;
-	}
-
-	public void setDefaultDeviceType(DeviceType defaultDeviceType) {
-		this.defaultDeviceType = defaultDeviceType;
-	}
-
-	public List<DeviceType> getDeviceTypes() {
-		// this might be better done on the DB side, but that seems like a recipe for weird behaviors
-		return configuredDevices.stream()
-			.filter(e -> !e.isDeleted())
-			.collect(Collectors.toList());
-	}
-
-	public void addDeviceType(DeviceType newDevice) {
-		configuredDevices.add(newDevice);
-	}
-
-	public void addDefaultDeviceType(DeviceType newDevice) {
-		this.defaultDeviceType = newDevice;
-		addDeviceType(newDevice);
-	}
-
-	public void removeDeviceType(DeviceType existingDevice) {
-		configuredDevices.remove(existingDevice);
-		if (defaultDeviceType != null && existingDevice.getInternalId().equals(defaultDeviceType.getInternalId())) {
-			defaultDeviceType = null;
-		}
-	}
-
-	public String getCliaNumber() {
-		return this.cliaNumber;
-	}
-
-	public Provider getOrderingProvider() {
-		return orderingProvider;
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Organization.java
@@ -29,7 +29,7 @@ public class Organization extends EternalEntity {
 		return organizationName;
 	}
 
-	public void setOrganizatioName(String newName) {
+	public void setOrganizationName(String newName) {
 		organizationName = newName;
 	}
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -11,6 +11,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import java.time.LocalDate;
 import java.util.List;
@@ -19,6 +20,9 @@ import java.util.List;
 @Entity
 public class Person extends OrganizationScopedEternalEntity {
 
+	@ManyToOne(optional = true)
+	@JoinColumn(name = "facility_id")
+	private Facility facility;
 	@Column
 	private String lookupId;
 	@Column(nullable = false)
@@ -57,10 +61,6 @@ public class Person extends OrganizationScopedEternalEntity {
 		super(org);
 		this.nameInfo = new PersonName(firstName, middleName, lastName, suffix);
 		this.role = PersonRole.STAFF;
-	}
-
-	public List<TestOrder> getTestOrders() {
-		return testOrders;
 	}
 
 	public Person(
@@ -130,6 +130,10 @@ public class Person extends OrganizationScopedEternalEntity {
 		this.employedInHealthcare = employedInHealthcare;
 	}
 
+	public Facility getFacility() {
+		return facility;
+	}
+
 	public String getLookupId() {
 		return lookupId;
 	}
@@ -183,18 +187,12 @@ public class Person extends OrganizationScopedEternalEntity {
 	}
 	@JsonIgnore
 	public String getStreet() {
-		if(address == null || address.getStreet() == null || address.getStreet().isEmpty()) {
-			return "";
-		}
-		return address.getStreet().get(0);
+		return address == null ? "" : address.getStreetOne();
 	}
 
 	@JsonIgnore
 	public String getStreetTwo() {
-		if(address == null || address.getStreet() == null || address.getStreet().size() < 2) {
-			return "";
-		}
-		return address.getStreet().get(1);
+		return address == null ? "" : address.getStreetTwo();
 	}
 
 	@JsonIgnore

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Provider.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Provider.java
@@ -4,6 +4,8 @@ import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 
+import org.springframework.boot.context.properties.ConstructorBinding;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
@@ -24,6 +26,7 @@ public class Provider extends EternalEntity {
 
 	protected Provider() { /* for hibernate */ }
 
+	@ConstructorBinding
 	public Provider(String firstName, String middleName, String lastName, String suffix, String providerId, StreetAddress address, String telephone) {
 		this.nameInfo = new PersonName(firstName, middleName, lastName, suffix);
 		this.providerId = providerId;
@@ -53,18 +56,12 @@ public class Provider extends EternalEntity {
 
 	@JsonIgnore
 	public String getStreet() {
-		if(address == null || address.getStreet() == null || address.getStreet().isEmpty()) {
-			return "";
-		}
-		return address.getStreet().get(0);
+		return address == null ? "" : address.getStreetOne();
 	}
 
 	@JsonIgnore
 	public String getStreetTwo() {
-		if(address == null || address.getStreet() == null || address.getStreet().size() < 2) {
-			return "";
-		}
-		return address.getStreet().get(1);
+		return address == null ? "" : address.getStreetTwo();
 	}
 
 	@JsonIgnore

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/StreetAddress.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/StreetAddress.java
@@ -3,6 +3,8 @@ package gov.cdc.usds.simplereport.db.model;
 import org.hibernate.annotations.Type;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import java.util.ArrayList;
@@ -56,6 +58,16 @@ public class StreetAddress {
 
     public List<String> getStreet() {
         return Collections.unmodifiableList(street);
+    }
+
+    @JsonIgnore
+    public String getStreetOne() { // if we're gonna do this, let's do it in one place
+        return street == null || street.isEmpty() ? "" : street.get(0);
+    }
+
+    @JsonIgnore
+    public String getStreetTwo() { // vide supra
+        return street == null || street.size() < 2 ? "" : street.get(1);
     }
 
     public void setStreet(String street1, String street2) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -26,11 +26,15 @@ public class TestEvent extends BaseTestInfo {
 
 	public TestEvent() {}
 
-	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Organization org) {
-		super(patient, org, deviceType, result);
+	public TestEvent(TestResult result, DeviceType deviceType, Person patient, Facility facility) {
+		super(patient, facility, deviceType, result);
 		// store a link, and *also* store the object as JSON
 		this.patientData = getPatient();
-		this.providerData = getOrganization().getOrderingProvider();
+		this.providerData = getFacility().getOrderingProvider();
+	}
+
+	public TestEvent(TestOrder order) {
+		this(order.getResult(), order.getDeviceType(), order.getPatient(), order.getFacility());
 	}
 
 	public Person getPatientData() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -36,8 +36,8 @@ public class TestOrder extends BaseTestInfo {
 
 	protected TestOrder() { /* for hibernate */ }
 
-	public TestOrder(Person patient) {
-		super(patient);
+	public TestOrder(Person patient, Facility facility) {
+		super(patient, facility);
 		this.orderStatus = OrderStatus.PENDING;
 	}
 	public OrderStatus getOrderStatus() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/readonly/NoJsonTestEvent.java
@@ -32,6 +32,6 @@ public class NoJsonTestEvent extends BaseTestInfo {
 	}
 
 	public Provider getProviderData() {
-		return getOrganization().getOrderingProvider();
+		return getFacility().getOrderingProvider(); // this could actually be gotten from JSON
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/FacilityRepository.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import java.util.Optional;
+
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+
+public interface FacilityRepository extends AuditedEntityRepository<Facility> {
+
+	public Optional<Facility> findByOrganizationAndFacilityName(Organization org, String facilityName);
+
+	public Optional<Facility> findFirstByOrganizationOrderByCreatedAt(Organization org);
+}

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -20,9 +20,13 @@ logging:
     gov.cdc.usds: DEBUG
 simple-report-initialization:
   organization:
-    facility-name: Dis Organization
+    org-name: Dis Organization
     external-id: DIS_ORG
+  facility:
+    facility-name: Injection Site
     clia-number: "000111222-3"
+    address:
+      street-1: 2797 N Cerrada de Beto
   provider:
     first-name: Fred
     last-name: Flintstone

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -586,12 +586,12 @@ databaseChangeLog:
       id: populate-facility-table
       author: bwarfield@cdc.gov
       comment: Populate facilities table based on existing organizations.
-      preconditions:
+      preConditions:
+        - onSqlOutput: FAIL
+        - onFail: MARK_RAN
         - sqlCheck:
-          sql:  SELECT count(1) > 0 FROM ${database.defaultSchemaName}.organization;
-          expectedResult: true
-          onSqlOutput: FAIL
-          onFail: MARK_RAN
+            sql:  SELECT count(1) > 0 FROM ${database.defaultSchemaName}.organization;
+            expectedResult: true
       changes:
         - sql:
             comment: Populate the facilities table from the organization table

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -194,7 +194,7 @@ databaseChangeLog:
                   remarks: The provider's contact phone number.
                   type: *string
         - createTable:
-            tableName: organization # may contain facility information as well, until/unless we split
+            tableName: organization
             remarks: A site where testing occurs, and also the main user grouping entity.
             columns:
               - column: *pk_column
@@ -506,3 +506,190 @@ databaseChangeLog:
               ALTER TABLE ${database.defaultSchemaName}.person
               ALTER COLUMN race TYPE text[]
               USING ARRAY[race];
+  - changeSet:
+      id: add-facility-table
+      author: bwarfield@cdc.gov
+      comment: Introduce the facility table, which takes over much of the data in the organization table
+      changes:
+        - createTable:
+            tableName: facility
+            remarks: A site where testing occurs (may be called "site" in user-facing language).
+            columns:
+              - column: *pk_column
+              - column: *created_at_column
+              - column: *created_by_column
+              - column: *updated_at_column
+              - column: *updated_by_column
+              - column: *soft_delete_column
+              - column:
+                  name: organization_id
+                  remarks: Foreign key to the organization that this facility belongs to.
+                  type: *idtype
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility__organization
+                    references: organization
+              - column:
+                  name: facility_name
+                  type: *string
+                  remarks: The human-readable name for this facility.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: clia_number
+                  type: *string # irony
+                  remarks: The CLIA number for the facility that is ordering (and presumably also conducting) the tests.
+              - column:
+                  name: default_device_type_id
+                  remarks: The default device type (if any) for tests at this facility.
+                  type: *idtype
+                  constraints:
+                    foreignKeyName: fk__facility__default_device_type
+                    references: device_type
+              - column:
+                  name: ordering_provider_id
+                  type: *idtype
+                  remarks: The healthcare provider who orders tests at this facility.
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility__ordering_provider
+                    references: provider
+              - column:
+                  name: street
+                  remarks: The street portion of the facility address.
+                  type: "text[]"
+              - column:
+                  name: city
+                  remarks: The city of the facility address.
+                  type: *string
+              - column:
+                  name: county
+                  remarks: The county (NOT THE COUNTRY) of the facility address, if applicable.
+                  type: *string
+              - column:
+                  name: state
+                  remarks: The state or province of the facility address.
+                  type: *string
+              - column:
+                  name: postal_code
+                  remarks: The zip/postal code of the facility address.
+                  type: *string
+              - column:
+                  name: telephone
+                  remarks: The facility's contact phone number.
+                  type: *string
+        - addUniqueConstraint:
+            tableName: facility
+            constraintName: uk__facility__organization_facility_name
+            columnNames: organization_id, facility_name
+  - changeSet:
+      id: populate-facility-table
+      author: bwarfield@cdc.gov
+      comment: Populate facilities table based on existing organizations.
+      preconditions:
+        - sqlCheck:
+          sql:  SELECT count(1) > 0 FROM ${database.defaultSchemaName}.organization;
+          expectedResult: true
+          onSqlOutput: FAIL
+          onFail: MARK_RAN
+      changes:
+        - sql:
+            comment: Populate the facilities table from the organization table
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.facility (
+                internal_id,
+                created_at, created_by, updated_at, updated_by,
+                facility_name, clia_number,
+                ordering_provider_id,
+                default_device_type_id
+              )
+              SELECT
+                gen_random_uuid(),
+                created_at, created_by, updated_at, updated_by,
+                facility_name, clia_number,
+                ordering_provider_id,
+                default_device_type
+              FROM ${database.defaultSchemaName}.organization;
+  - changeSet:
+      id: add-facility-relationships
+      author: bwarfield@cdc.gov
+      comment: Add relationships and otherwise modify other tables in the schema to reflect the existence of facilities.
+      # we may want a check constraint on patient.facility (and arguably
+      # test_order.facility and test_event.facility as well) to make sure that
+      # the facility belongs to the correct organization
+      changes:
+        - dropConstraint:
+            tableName: organization
+            constraintName: uk__facility__name
+        - renameColumn:
+            tableName: organization
+            oldColumnName: facility_name
+            newColumnName: organization_name
+            remarks: The human-readable name for this organization.
+        - addUniqueConstraint:
+            tableName: organization
+            constraintName: uk__organization__organization_name
+            columnNames: organization_name
+        - addColumn:
+            tableName: person
+            columns:
+              - column:
+                  name: facility_id
+                  afterColumn: organization_id
+                  type: *idtype
+                  valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
+                  remarks: The facility where this person is expected to be tested (null if they will be tested at multiple sites)
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk__person__facility
+                    referencedTableName: facility
+        - addColumn:
+            tableName: test_event
+            columns:
+              - column:
+                  name: facility_id
+                  afterColumn: organization_id
+                  type: *idtype
+                  remarks: The facility where this test took place.
+                  valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__test_event__facility
+                    referencedTableName: facility
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: facility_id
+                  afterColumn: organization_id
+                  type: *idtype
+                  remarks: The facility where this test was ordered.
+                  valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__test_order__facility
+                    referencedTableName: facility
+        - addColumn:
+            tableName: facility_device_type
+            columns:
+              - column:
+                  name: facility_id
+                  afterColumn: organization_id
+                  type: *idtype
+                  valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_device_type__facility
+                    referencedTableName: facility
+        - dropColumn:
+            tableName: facility_device_type
+            columnName: organization_id
+        - dropColumn:
+            tableName: organization
+            columns:
+              - column:
+                  name: clia_number
+              - column:
+                  name: default_device_type
+              - column:
+                  name: ordering_provider_id

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -598,14 +598,16 @@ databaseChangeLog:
             sql: |
               INSERT INTO ${database.defaultSchemaName}.facility (
                 internal_id,
-                created_at, created_by, updated_at, updated_by,
+                organization_id,
+                created_at, created_by, updated_at, updated_by, is_deleted,
                 facility_name, clia_number,
                 ordering_provider_id,
                 default_device_type_id
               )
               SELECT
                 gen_random_uuid(),
-                created_at, created_by, updated_at, updated_by,
+                internal_id,
+                created_at, created_by, updated_at, updated_by, is_deleted,
                 facility_name, clia_number,
                 ordering_provider_id,
                 default_device_type
@@ -653,9 +655,11 @@ databaseChangeLog:
                   remarks: The facility where this test took place.
                   valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
                   constraints:
-                    nullable: false
                     foreignKeyName: fk__test_event__facility
                     referencedTableName: facility
+        - addNotNullConstraint:
+            tableName: test_event
+            columnName: facility_id
         - addColumn:
             tableName: test_order
             columns:
@@ -666,9 +670,11 @@ databaseChangeLog:
                   remarks: The facility where this test was ordered.
                   valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
                   constraints:
-                    nullable: false
                     foreignKeyName: fk__test_order__facility
                     referencedTableName: facility
+        - addNotNullConstraint:
+            tableName: test_order
+            columnName: facility_id
         - addColumn:
             tableName: facility_device_type
             columns:
@@ -678,9 +684,11 @@ databaseChangeLog:
                   type: *idtype
                   valueComputed: (select internal_id from ${database.defaultSchemaName}.facility f where f.organization_id = organization_id) 
                   constraints:
-                    nullable: false
                     foreignKeyName: fk__facility_device_type__facility
                     referencedTableName: facility
+        - addNotNullConstraint:
+            tableName: facility_device_type
+            columnName: facility_id
         - dropColumn:
             tableName: facility_device_type
             columnName: organization_id

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/OrganizationFacilityTest.java
@@ -29,7 +29,7 @@ public class OrganizationFacilityTest extends BaseApiTest {
 		ObjectNode orgNode = (ObjectNode) resp.get("organization");
 		JsonNode facNode = orgNode.path("testingFacility");
 		assertTrue(facNode.isObject(), "facility should be an object in response");
-		assertEquals("Dis Organization", facNode.get("name").asText());
+		assertEquals("Injection Site", facNode.get("name").asText());
 		assertEquals("000111222-3", facNode.get("cliaNumber").asText());
 		assertEquals("2797 N Cerrada de Beto", facNode.get("street").asText()); // oh my
 		ArrayNode typeList = (ArrayNode) orgNode.get("deviceTypes");
@@ -46,7 +46,7 @@ public class OrganizationFacilityTest extends BaseApiTest {
 		ObjectNode who = (ObjectNode) resp.get("whoami");
 		assertEquals("Bobbity", who.get("firstName").asText());
 		ObjectNode facNode = (ObjectNode) who.get("organization").get("testingFacility");
-		assertEquals("Dis Organization", facNode.get("name").asText());
+		assertEquals("Injection Site", facNode.get("name").asText());
 	}
 
 	@Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/FacilityRepositoryTest.java
@@ -1,0 +1,52 @@
+package gov.cdc.usds.simplereport.db.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Provider;
+
+public class FacilityRepositoryTest extends BaseRepositoryTest {
+
+	@Autowired
+	private DeviceTypeRepository _devices;
+	@Autowired
+	private ProviderRepository _providers;
+	@Autowired
+	private OrganizationRepository _orgs;
+	@Autowired
+	private FacilityRepository _repo;
+
+	@Test
+	public void smokeTestDeviceOperations() {
+		Set<DeviceType> configuredDevices = new HashSet<>();
+		DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6");
+		Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
+		configuredDevices.add(_devices.save(bill));
+		configuredDevices.add(_devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7")));
+		Organization org = _orgs.save(new Organization("My Office", "650Mass"));
+		Facility saved = _repo.save(new Facility(org, "Third Floor", "123456", mccoy, bill, configuredDevices));
+		Optional<Facility> maybe = _repo.findByOrganizationAndFacilityName(org, "Third Floor");
+		assertTrue(maybe.isPresent(), "should find the facility");
+		Facility found = maybe.get();
+		assertEquals(2, found.getDeviceTypes().size());
+		found.addDefaultDeviceType(bill);
+		_repo.save(found);
+		found = _repo.findById(saved.getInternalId()).get();
+		found.removeDeviceType(bill);
+		_repo.save(found);
+		found = _repo.findById(saved.getInternalId()).get();
+		assertNull(found.getDefaultDeviceType());
+		assertEquals(1, found.getDeviceTypes().size());
+	}
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/OrganizationRepositoryTest.java
@@ -2,33 +2,23 @@ package gov.cdc.usds.simplereport.db.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Organization;
-import gov.cdc.usds.simplereport.db.model.Provider;
 
 public class OrganizationRepositoryTest extends BaseRepositoryTest {
 
 	@Autowired
 	private OrganizationRepository _repo;
-	@Autowired
-	private DeviceTypeRepository _devices;
-	@Autowired
-	private ProviderRepository _providers;
 
 	@Test
 	public void createAndFindSomething() {
-		Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
-		Organization saved = _repo.save(new Organization("My House", "12345", "54321", null, mccoy));
+		Organization saved = _repo.save(new Organization("My House", "12345"));
 		assertNotNull(saved);
 		assertNotNull(saved.getInternalId());
 		Optional<Organization> sameOrg = _repo.findByExternalId("12345");
@@ -36,23 +26,4 @@ public class OrganizationRepositoryTest extends BaseRepositoryTest {
 		assertEquals(sameOrg.get().getInternalId(), saved.getInternalId());
 	}
 
-	@Test
-	public void smokeTestDeviceOperations() {
-		Set<DeviceType> configuredDevices = new HashSet<>();
-		DeviceType bill = new DeviceType("Bill", "Weasleys", "1", "12345-6");
-		Provider mccoy = _providers.save(new Provider("Doc", "", "", "", "NCC1701", null, "(1) (111) 2222222"));
-		configuredDevices.add(_devices.save(bill));
-		configuredDevices.add(_devices.save(new DeviceType("Percy", "Weasleys", "2", "12345-7")));
-		Organization saved = _repo.save(new Organization("My Office", "DHSHQ", "650Mass", null, mccoy, configuredDevices));
-		Organization found = _repo.findByExternalId(saved.getExternalId()).get();
-		assertEquals(2, found.getDeviceTypes().size());
-		found.addDefaultDeviceType(bill);
-		_repo.save(found);
-		found = _repo.findById(saved.getInternalId()).get();
-		found.removeDeviceType(bill);
-		_repo.save(found);
-		found = _repo.findById(saved.getInternalId()).get();
-		assertNull(found.getDefaultDeviceType());
-		assertEquals(1, found.getDeviceTypes().size());
-	}
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/PersonRepositoryTest.java
@@ -5,14 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.LocalDate;
 import java.util.List;
 
-import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
+import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 
 public class PersonRepositoryTest extends BaseRepositoryTest {
 
@@ -20,15 +19,11 @@ public class PersonRepositoryTest extends BaseRepositoryTest {
 	private PersonRepository _repo;
 	@Autowired
 	private OrganizationRepository _orgRepo;
-	@Autowired
-	private ProviderRepository _providerRepo;
 
 	@Test
 	public void doPersonOperations() {
-		Provider goodDoc = _providerRepo.save(new Provider("Madam", "", "Pomfrey", "", "YAY", null, ""));
-		Provider badDoc = _providerRepo.save(new Provider("Gilderoy", "", "Lockhart", "", "UHOH", null, ""));
-		Organization org = _orgRepo.save(new Organization("Here", "there", "stranger", null, goodDoc));
-		Organization other = _orgRepo.save(new Organization("There", "where?", "WOLF",  null, badDoc));
+		Organization org = _orgRepo.save(new Organization("Here", "there"));
+		Organization other = _orgRepo.save(new Organization("There", "where?"));
 
 		StreetAddress addy = new StreetAddress("123 4th Street", null, "Washington", "DC", "20001", null);
 		_repo.save(new Person(org, "lookupid", "Joe", null, "Schmoe", null, LocalDate.now(),  addy, "(123) 456-7890", PersonRole.VISITOR, "", null, "", "", false, false));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestEventRepositoryTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
@@ -23,9 +24,10 @@ public class TestEventRepositoryTest extends BaseRepositoryTest {
 	@Test
 	public void testFindByPatient() {
 		Organization org = _dataFactory.createValidOrg();
+		Facility place = _dataFactory.createValidFacility(org);
 		Person patient = _dataFactory.createMinimalPerson(org);
-		_repo.save(new TestEvent(TestResult.POSITIVE, org.getDefaultDeviceType(), patient, org));
-		_repo.save(new TestEvent(TestResult.UNDETERMINED, org.getDefaultDeviceType(), patient, org));
+		_repo.save(new TestEvent(TestResult.POSITIVE, place.getDefaultDeviceType(), patient, place));
+		_repo.save(new TestEvent(TestResult.UNDETERMINED, place.getDefaultDeviceType(), patient, place));
 		flush();
 		List<TestEvent> found = _repo.findAllByPatient(patient);
 		assertEquals(2, found.size());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -9,13 +9,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
+import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 
 public class OrganizationServiceTest extends BaseRepositoryTest {
 
 	private OrganizationService _service;
 	
-	public OrganizationServiceTest(@Autowired OrganizationRepository repo, @Autowired OrganizationInitializingService initService) {
-		_service = new OrganizationService(repo, initService);
+	public OrganizationServiceTest(@Autowired OrganizationRepository repo, @Autowired FacilityRepository facilityRepo,
+			@Autowired OrganizationInitializingService initService) {
+		_service = new OrganizationService(repo, facilityRepo, initService);
 	}
 
 	@Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.repository	.BaseRepositoryTest;
+import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 
@@ -18,8 +19,9 @@ public class PersonServiceTest extends BaseRepositoryTest {
 
 	private PersonService _service;
 
-	public PersonServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
-		OrganizationService os= new OrganizationService(orgRepo, initService);
+	public PersonServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired FacilityRepository facilityRepo,
+			@Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
+		OrganizationService os= new OrganizationService(orgRepo, facilityRepo, initService);
 		_service = new PersonService(os, repo);
 	}
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
+import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 
@@ -30,8 +31,8 @@ class UploadServiceTest extends BaseRepositoryTest {
     private final PersonService _ps;
     private final UploadService _service;
 
-    public UploadServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
-        OrganizationService os = new OrganizationService(orgRepo, initService);
+    public UploadServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired FacilityRepository facilityRepo, @Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
+        OrganizationService os = new OrganizationService(orgRepo, facilityRepo, initService);
         this._ps = new PersonService(os, repo);
         this._service = new UploadService(_ps);
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -3,16 +3,19 @@ package gov.cdc.usds.simplereport.test_util;
 import java.time.LocalDate;
 import java.util.Collections;
 
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
 import gov.cdc.usds.simplereport.db.model.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
@@ -24,6 +27,8 @@ public class TestDataFactory {
 	@Autowired
 	private OrganizationRepository _orgRepo;
 	@Autowired
+	private FacilityRepository _facilityRepo;
+	@Autowired
 	private PersonRepository _personRepo;
 	@Autowired
 	private ProviderRepository _providerRepo;
@@ -31,10 +36,19 @@ public class TestDataFactory {
 	private DeviceTypeRepository _deviceRepo;
 
 	public Organization createValidOrg() {
+		return _orgRepo.save(new Organization("The Mall", "MALLRAT"));
+	}
+
+	public Facility createValidFacility(Organization org) {
 		DeviceType dev = getGenericDevice();
 		StreetAddress addy = new StreetAddress(Collections.singletonList("Moon Base"), "Luna City", "THE MOON", "", "");
 		Provider doc = _providerRepo.save(new Provider("Doctor", "", "Doom", "", "DOOOOOOM", addy, "1-900-CALL-FOR-DOC")); 
-		return _orgRepo.save(new Organization("The Mall", "MALLRAT", "123456", dev, doc));
+		Facility facility = new Facility(org, "Test Site Alpha", "123456", doc);
+		facility.setAddress(addy);
+		facility.setDefaultDeviceType(dev);
+		Facility save = _facilityRepo.save(facility);
+		LoggerFactory.getLogger("DERPDERPDERP").warn("Facility looks like {}", save);
+		return save;
 	}
 
 	public Person createMinimalPerson(Organization org) {


### PR DESCRIPTION
Added a database object for facilities, and migrations such that all existing organizations have exactly one facility, then updated API handlers such that attempts to modify the fields of an organization
that now reside on its (single) facility will instead be performed on the facility object.

Also did a minor refactor to eliminate some boilerplate about street addresses, and updated many, many tests.

Gotchas:
* the database migration to populate the `facility` table requires the `pgcrypto` module to be enabled in postgresql. It will be skipped if run on an empty database, but we should enable that module for deployed environments
  - [x] run `create extension if not exists pgcrypto;` on cloud.gov database
  - [x] run `create extension if not exists pgcrypto;` on demo database
  - [x] run `create extension if not exists pgcrypto;` on staging database
  - [ ] run `create extension if not exists pgcrypto;` on prod database
  - [x] figure out how to let people run `create extension if not exists pgcrypto;` on their local dev databases without nuking.
    ```sh
    docker-compose exec -u postgres db psql -h localhost -p ${SR_DB_PORT:-5432} -c 'create extension if not exists pgcrypto' simple_report
    ```
* certain facility information is currently hard-coded in our export because it isn't in the database. This change adds support for pulling it from the database, but not for inserting it—we should probably just restore the hard-coded values until we actually support editing them through the UI.