### PR TITLE
Look up previous results when putting test in the queue

### DIFF
--- a/frontend/src/app/constants/index.jsx
+++ b/frontend/src/app/constants/index.jsx
@@ -9,3 +9,9 @@ export const TEST_RESULT_VALUES = {
   1: COVID_RESULTS.POSITIVE,
   2: COVID_RESULTS.INCONCLUSIVE,
 };
+
+export const TEST_RESULT_DESCRIPTIONS = {
+  NEGATIVE: "Negative",
+  POSITIVE: "Positive",
+  UNDETERMINED: "Inconclusive",
+};

--- a/frontend/src/app/testQueue/TestQueue.jsx
+++ b/frontend/src/app/testQueue/TestQueue.jsx
@@ -42,6 +42,7 @@ const queueQuery = gql`
         firstName
         middleName
         lastName
+        gender
       }
     }
     organization {

--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.jsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.jsx
@@ -24,6 +24,7 @@ const QUERY_PATIENT = gql`
       lastName
       middleName
       birthDate
+      gender
     }
   }
 `;

--- a/frontend/src/app/testResults/TestResultInputForm.jsx
+++ b/frontend/src/app/testResults/TestResultInputForm.jsx
@@ -3,16 +3,10 @@ import PropTypes from "prop-types";
 
 import RadioGroup from "../commonComponents//RadioGroup";
 import Button from "../commonComponents//Button";
-import Anchor from "../commonComponents/Anchor";
-import { COVID_RESULTS } from "../constants";
+import { COVID_RESULTS, TEST_RESULT_DESCRIPTIONS } from "../constants";
 import { v4 as uuidv4 } from "uuid";
 
-const TestResultInputForm = ({
-  testResultValue,
-  onSubmit,
-  onChange,
-  onClearClick,
-}) => {
+const TestResultInputForm = ({ testResultValue, onSubmit, onChange }) => {
   const testResultForm = (
     <React.Fragment>
       <RadioGroup
@@ -20,17 +14,15 @@ const TestResultInputForm = ({
         buttons={[
           {
             value: COVID_RESULTS.POSITIVE,
-            label: "Positive (+)",
-            failure: true,
+            label: `${TEST_RESULT_DESCRIPTIONS.POSITIVE} (+)`,
           },
           {
             value: COVID_RESULTS.NEGATIVE,
-            label: "Negative (-)",
-            success: true,
+            label: `${TEST_RESULT_DESCRIPTIONS.NEGATIVE} (-)`,
           },
           {
             value: COVID_RESULTS.INCONCLUSIVE,
-            label: "Inconclusive",
+            label: `${TEST_RESULT_DESCRIPTIONS.UNDETERMINED}`,
           },
         ]}
         name={`covid-test-result-${uuidv4()}`}
@@ -44,7 +36,6 @@ const TestResultInputForm = ({
           outline
           label="Submit"
         />
-        <Anchor onClick={onClearClick} text="Clear" />
       </div>
     </React.Fragment>
   );

--- a/frontend/src/app/testResults/TestResultsList.jsx
+++ b/frontend/src/app/testResults/TestResultsList.jsx
@@ -9,7 +9,7 @@ import {
 import { PATIENT_TERM_CAP } from "../../config/constants";
 import { displayFullName } from "../utils";
 
-const testResultQuery = gql`
+export const testResultQuery = gql`
   {
     testResults {
       internalId

--- a/frontend/src/scss/PrimeStyles.scss
+++ b/frontend/src/scss/PrimeStyles.scss
@@ -71,6 +71,13 @@
   border-bottom: 1px solid color($theme-color-prime-gray-light);
 }
 
+.prime-previous-test-display {
+  font-size: 90%;
+  margin-left: 0.5em;
+  border-left: 4px solid #ccc;
+  padding-left: 0.5em;
+}
+
 // things that look like links but aren't links
 
 .prime-link {
@@ -139,12 +146,10 @@
   list-style-type: none;
   margin-top: 0;
   padding: 0;
-  text-align: center;
 }
 .prime-radio--horizontal__container {
   position: relative;
   display: list-item;
-  width: 45%;
   max-width: 5rem;
   float: left;
   margin: 0;


### PR DESCRIPTION
This was rather hairy because I didn't want to add permanent database state. On a return visit to the AoE modal I had to infer whether they had previously answered the yes/no question about the last test we saw. I think I got this logic right...

We need to get rid of the CMS design system dialog but I wanted to save it for a separate PR.