### PR TITLE
Make SR app visible in Okta

### DIFF
--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -7,25 +7,30 @@ locals {
     "https://prime-data-input-sandbox-backend.app.cloud.gov/",
     "https://staging.simplereport.org/app"
   ]
+  is_prod = var.env == "prod"
+  app_url = local.is_prod ? "https://simplereport.cdc.gov/app" : "https://${var.env}.simplereport.cdc.gov"
 }
 
 
 resource "okta_app_oauth" "app" {
-  label = "Simple Report (${var.env})"
-  type  = "web"
+  label = local.is_prod ? "Simple Report" : "Simple Report (${var.env})"
+  type = "web"
   grant_types = [
     "authorization_code",
-  "implicit"]
+    "implicit"]
   redirect_uris = concat(local.dev_urls, [
-  "https://${var.env}.simplereport.org/app", "https://simplereport.cdc.gov/app"])
+    "https://${var.env}.simplereport.org/app",
+    "https://simplereport.cdc.gov/app"])
   response_types = [
     "code",
     "id_token",
-  "token"]
-  login_uri = "https://prime-data-input-sandbox-backend.app.cloud.gov/"
+    "token"]
+  login_uri = local.app_url
   post_logout_redirect_uris = [
     "https://simplereport.cdc.gov"
   ]
+  hide_ios = false
+  hide_web = false
 
   lifecycle {
     ignore_changes = [
@@ -37,26 +42,26 @@ resource "okta_app_oauth" "app" {
 // Create the custom app mappings
 
 resource "okta_app_user_schema" "org_schema" {
-  app_id      = okta_app_oauth.app.id
-  index       = "simple_report_org"
-  title       = "Healthcare Organization"
+  app_id = okta_app_oauth.app.id
+  index = "simple_report_org"
+  title = "Healthcare Organization"
   description = "Associated Healthcare Organization"
-  type        = "string"
-  master      = "PROFILE_MASTER"
+  type = "string"
+  master = "PROFILE_MASTER"
 }
 
 resource "okta_app_user_schema" "user_schema" {
-  app_id      = okta_app_oauth.app.id
-  index       = "simple_report_user"
-  title       = "User Type"
+  app_id = okta_app_oauth.app.id
+  index = "simple_report_user"
+  title = "User Type"
   description = "Whether or not the user is an administrator"
-  type        = "string"
-  master      = "PROFILE_MASTER"
+  type = "string"
+  master = "PROFILE_MASTER"
 }
 
 resource "okta_app_group_assignment" "users" {
-  count    = length(var.user_groups)
-  app_id   = okta_app_oauth.app.id
+  count = length(var.user_groups)
+  app_id = okta_app_oauth.app.id
   group_id = element(var.user_groups, count.index)
 }
 
@@ -66,6 +71,6 @@ data "okta_group" "cdc_users" {
 }
 
 resource "okta_app_group_assignment" "prime_users" {
-  app_id   = okta_app_oauth.app.id
+  app_id = okta_app_oauth.app.id
   group_id = data.okta_group.cdc_users.id
 }

--- a/ops/services/okta-app/main.tf
+++ b/ops/services/okta-app/main.tf
@@ -8,7 +8,7 @@ locals {
     "https://staging.simplereport.org/app"
   ]
   is_prod = var.env == "prod"
-  app_url = local.is_prod ? "https://simplereport.cdc.gov/app" : "https://${var.env}.simplereport.cdc.gov"
+  app_url = local.is_prod ? "https://simplereport.cdc.gov/app" : "https://${var.env}.simplereport.org/app"
 }
 
 


### PR DESCRIPTION
## Related Issue or Background Info

- Users were getting confused when presented with `no assigned applications` when visiting the main Okta page. That was confusing and a bad user experience.
It turned out the issue was due to a setting in the app configuration which prevented login actions from the Okta app; which apparently makes it invisible as well.

## Changes Proposed

- Update the Okta application settings to allow logins from the web and mobile apps.
- This should help address the confusion when presented with 'no assigned apps' in the main Okta page.
- Also updated the application name to remove the 'prod' tag in production.
