### PR TITLE
Fix service testing

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/DevSecurityConfiguration.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -16,6 +17,7 @@ import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
  */
 @Profile(DevSecurityConfiguration.PROFILE)
 @Configuration
+@ConditionalOnWebApplication
 public class DevSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(DevSecurityConfiguration.class);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -33,6 +34,7 @@ import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 @Configuration
 @Profile("!" + DevSecurityConfiguration.PROFILE) // Activate this profile to disable security
 @EnableGlobalMethodSecurity(prePostEnabled = true)
+@ConditionalOnWebApplication
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public static final String SAVED_REQUEST_HEADER = "SPRING_SECURITY_SAVED_REQUEST";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -21,10 +21,12 @@ import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
 @SpringBootTest(properties = "spring.main.web-application-type=NONE")
 @ActiveProfiles("dev")
 @Import(SliceTestConfiguration.class)
-public class BaseServiceTest {
+public class BaseServiceTest<T> {
 
 	@Autowired
 	private DbTruncator _truncator;
+	@Autowired
+	protected T _service;
 
 	@BeforeEach
 	public void clearDb() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/BaseServiceTest.java
@@ -1,0 +1,37 @@
+package gov.cdc.usds.simplereport.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import gov.cdc.usds.simplereport.test_util.DbTruncator;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+
+/**
+ * Base class for service-level integration. Avoids setting up servlet
+ * and web security, but sets up service and persistence layer.
+ *
+ * Note that when service-layer security is configured, it will mysteriously
+ * not work in tests because security configuration is attached to a web
+ * security configuration module. (That module is also on the wrong profile,
+ * so there's a significant rearrangement required regardless.)
+ */
+@SpringBootTest(properties = "spring.main.web-application-type=NONE")
+@ActiveProfiles("dev")
+@Import(SliceTestConfiguration.class)
+public class BaseServiceTest {
+
+	@Autowired
+	private DbTruncator _truncator;
+
+	@BeforeEach
+	public void clearDb() {
+		_truncator.truncateAll();
+	}
+
+	protected void reset() {
+		_truncator.truncateAll();
+	}
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -10,17 +10,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.DeviceType;
-import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
-import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 
-public class DeviceTypeServiceTest extends BaseRepositoryTest {
+public class DeviceTypeServiceTest extends BaseServiceTest {
 
 	@Autowired
-	private DeviceTypeRepository _repo;
+	private DeviceTypeService _service;
 
 	@Test
 	public void insertAndFindAndDeleteAndSoForth() {
-		DeviceTypeService _service = new DeviceTypeService(_repo);
 		DeviceType devA = _service.createDeviceType("A", "B", "C", "DUMMY");
 		DeviceType devB = _service.createDeviceType("D", "E", "F", "DUMMY");
 		assertNotNull(devA);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeServiceTest.java
@@ -7,14 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 
-public class DeviceTypeServiceTest extends BaseServiceTest {
-
-	@Autowired
-	private DeviceTypeService _service;
+public class DeviceTypeServiceTest extends BaseServiceTest<DeviceTypeService> {
 
 	@Test
 	public void insertAndFindAndDeleteAndSoForth() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -7,19 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
-import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
-import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 
-public class OrganizationServiceTest extends BaseRepositoryTest {
+public class OrganizationServiceTest extends BaseServiceTest {
 
+	@Autowired
 	private OrganizationService _service;
 	
-	public OrganizationServiceTest(@Autowired OrganizationRepository repo, @Autowired FacilityRepository facilityRepo,
-			@Autowired OrganizationInitializingService initService) {
-		_service = new OrganizationService(repo, facilityRepo, initService);
-	}
-
 	@Test
 	public void findit() {
 		Organization org = _service.getCurrentOrganization();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -4,14 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Organization;
 
-public class OrganizationServiceTest extends BaseServiceTest {
-
-	@Autowired
-	private OrganizationService _service;
+public class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 	
 	@Test
 	public void findit() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -9,21 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Person;
-import gov.cdc.usds.simplereport.db.repository	.BaseRepositoryTest;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
-import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
-import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class PersonServiceTest extends BaseRepositoryTest {
+public class PersonServiceTest extends BaseServiceTest {
 
+	@Autowired
 	private PersonService _service;
-
-	public PersonServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired FacilityRepository facilityRepo,
-			@Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
-		OrganizationService os= new OrganizationService(orgRepo, facilityRepo, initService);
-		_service = new PersonService(os, repo);
-	}
 
 	@Test
 	public void roundTrip() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/PersonServiceTest.java
@@ -6,15 +6,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import gov.cdc.usds.simplereport.db.model.Person;
 
 @SuppressWarnings("checkstyle:MagicNumber")
-public class PersonServiceTest extends BaseServiceTest {
-
-	@Autowired
-	private PersonService _service;
+public class PersonServiceTest extends BaseServiceTest<PersonService> {
 
 	@Test
 	public void roundTrip() {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -18,24 +18,13 @@ import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
-import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
-import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
-import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 
-/**
- * Created by nickrobison on 11/21/20
- */
-class UploadServiceTest extends BaseRepositoryTest {
+class UploadServiceTest extends BaseServiceTest {
 
-    private final PersonService _ps;
-    private final UploadService _service;
-
-    public UploadServiceTest(@Autowired OrganizationRepository orgRepo, @Autowired FacilityRepository facilityRepo, @Autowired OrganizationInitializingService initService, @Autowired PersonRepository repo) {
-        OrganizationService os = new OrganizationService(orgRepo, facilityRepo, initService);
-        this._ps = new PersonService(os, repo);
-        this._service = new UploadService(_ps);
-    }
+    @Autowired
+    private PersonService _ps;
+    @Autowired
+    private UploadService _service;
 
     @Test
     void testInsert() throws IOException {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/UploadServiceTest.java
@@ -19,12 +19,10 @@ import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 
-class UploadServiceTest extends BaseServiceTest {
+class UploadServiceTest extends BaseServiceTest<UploadService> {
 
     @Autowired
     private PersonService _ps;
-    @Autowired
-    private UploadService _service;
 
     @Test
     void testInsert() throws IOException {


### PR DESCRIPTION
## Related Issue or Background Info

Our regression tests for the service layer of the API were brittle and sometimes failed because of the order in which tests were run.

## Changes Proposed

Create test infrastructure that allows services that integrate with the database to be tested fully without running the full graphql stack on top of them.
