### PR TITLE
Removed default values from dropdowns in AoE questionaire

### DIFF
--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -96,8 +96,8 @@ const PriorTestInputs = ({
   mostRecentTest,
 }) => {
   const filledPriorTest =
-    (mostRecentTest.dateTested || "").split("T")[0] === priorTestDate &&
-    mostRecentTest.result === priorTestResult;
+    (mostRecentTest ? mostRecentTest.dateTested : "").split("T")[0] ===
+      priorTestDate && mostRecentTest.result === priorTestResult;
   const [mostRecentTestAnswer, setMostRecentTestAnswer] = useState(
     isFirstTest === undefined ? undefined : filledPriorTest ? "yes" : "no"
   );
@@ -117,6 +117,7 @@ const PriorTestInputs = ({
         name="prior_test_type"
         selectedValue={priorTestType}
         onChange={(e) => setPriorTestType(e.target.value)}
+        includeUndefined
       />
       <Dropdown
         options={[
@@ -136,6 +137,7 @@ const PriorTestInputs = ({
         label="Result of Prior Test"
         name="prior_test_result"
         selectedValue={priorTestResult}
+        includeUndefined
         onChange={(e) => setPriorTestResult(e.target.value)}
       />
     </>
@@ -205,7 +207,9 @@ const PriorTestInputs = ({
           { label: "Yes", value: "yes" },
           { label: "No", value: "no" },
         ]}
-        selectedRadio={String(isFirstTest)}
+        selectedRadio={
+          isFirstTest === true ? "yes" : isFirstTest === false ? "no" : ""
+        }
         onChange={(e) => {
           setIsFirstTest(e.target.value === "yes");
         }}

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -306,7 +306,7 @@ const AoEModalForm = ({
           firstTest: false,
           priorTestDate: priorTestDate,
           priorTestType: priorTestType,
-          priorTestResult: priorTestResult,
+          priorTestResult: priorTestResult ? priorTestResult : null,
         };
 
     saveCallback({

--- a/frontend/src/scss/AppLayout.scss
+++ b/frontend/src/scss/AppLayout.scss
@@ -61,10 +61,10 @@ main {
 .prime-form-line {
   display: flex;
   flex-flow: row wrap;
-}
-.prime-text-input,
-.prime-dropdown {
-  margin-left: 2em;
+
+  > * {
+    margin-left: 2em;
+  }
 }
 .prime-radios,
 .prime-checkboxes {


### PR DESCRIPTION
## Related Issue or Background Info

- https://github.com/CDCgov/prime-data-input-client/issues/269
- part of: https://github.com/CDCgov/prime-central/issues/176

## Changes Proposed

- fixed an untracked bug where the app crashes if you add a patient to the queue with no previous test results.
- fixed an untracked bug where the "is this your first covid test" radio button wouldn't actually render the yes/no value
- "type of prior test" and "result of prior test" dropdowns now default to "- Select -" instead of the first value
- removed left margins for text inputs and dropdowns

## Additional Information

- please QA

## Screenshots / Demos
<img width="430" alt="Screen Shot 2020-12-09 at 1 05 33 PM" src="https://user-images.githubusercontent.com/35268641/101687367-3e62ed80-3a1f-11eb-90dd-1019f9c77c0c.png">
