### PR TITLE
Added graphql query linting via existing eslint script.

### DIFF
--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -95,3 +95,28 @@ jobs:
           key: gradle-${{ hashFiles('*.gradle', 'gradle/dependency-locks/*') }}
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain
+  schema-check:
+    strategy:
+      matrix:
+        node: [14]
+        os: [ubuntu-20.04]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{matrix.node}}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.node}}
+      - name: Cache npm local files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ./frontend/node_modules
+          key: npm-${{matrix.node}}-${{ hashFiles('frontend/package-lock.json', 'frontend/package.json') }}
+      - name: Node setup
+        working-directory: ./frontend
+        run: npm install
+      - name: Lint front-end code with eslint to check graphql queries
+        working-directory: ./frontend
+        run: npm run-script lint:eslint

--- a/.github/workflows/smoketestBackend.yml
+++ b/.github/workflows/smoketestBackend.yml
@@ -9,6 +9,10 @@ on:
       - "backend/**"
       - .github/workflows/smoketestBackend.yml
 
+env:
+  NODE_VERSION: 14
+  JAVA_VERSION: 11
+
 defaults:
   run:
     working-directory: backend
@@ -31,10 +35,10 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{env.JAVA_VERSION}}
       - name: Cache Java Dependencies
         uses: actions/cache@v2
         with:
@@ -65,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{env.JAVA_VERSION}}
       - name: Cache Java Dependencies
         uses: actions/cache@v2
         with:
@@ -82,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{env.JAVA_VERSION}}
       - name: Cache Java Dependencies
         uses: actions/cache@v2
         with:
@@ -96,24 +100,20 @@ jobs:
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain
   schema-check:
-    strategy:
-      matrix:
-        node: [14]
-        os: [ubuntu-20.04]
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{matrix.node}}
+      - name: Use Node.js ${{env.NODE_VERSION}}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.node}}
+          node-version: ${{env.NODE_VERSION}}
       - name: Cache npm local files
         uses: actions/cache@v2
         with:
           path: |
             ~/.npm
             ./frontend/node_modules
-          key: npm-${{matrix.node}}-${{ hashFiles('frontend/package-lock.json', 'frontend/package.json') }}
+          key: npm-${{env.NODE_VERSION}}-${{ hashFiles('frontend/package-lock.json', 'frontend/package.json') }}
       - name: Node setup
         working-directory: ./frontend
         run: npm install

--- a/frontend/.graphqlrc
+++ b/frontend/.graphqlrc
@@ -1,0 +1,1 @@
+schema: ../backend/src/main/resources/schema.graphqls

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,23 @@
         }
       }
     },
+    "@ardatan/aggregate-error": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
+      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -1191,6 +1208,26 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@endemolshinegroup/cosmiconfig-typescript-loader": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
+      "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4",
+        "make-error": "^1",
+        "ts-node": "^9",
+        "tslib": "^2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.32",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
@@ -1225,6 +1262,835 @@
       "integrity": "sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "@graphql-tools/batch-execute": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-7.0.0.tgz",
+      "integrity": "sha512-+ywPfK6N2Ddna6oOa5Qb1Mv7EA8LOwRNOAPP9dL37FEhksJM9pYqPSceUcqMqg7S9b0+Cgr78s408rgvurV3/Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^7.0.0",
+        "dataloader": "2.0.0",
+        "is-promise": "4.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/delegate": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.7.tgz",
+      "integrity": "sha512-2sze+CJxu37b4jcQ4fyj6ap9TMnx8+NBtApSs1nWIVENzPE2510aNTsBHgSdTwSeV/tVIFkAtZZAlMEGYGXzQA==",
+      "dev": true,
+      "requires": {
+        "@ardatan/aggregate-error": "0.0.6",
+        "@graphql-tools/batch-execute": "^7.0.0",
+        "@graphql-tools/schema": "^7.0.0",
+        "@graphql-tools/utils": "^7.0.2",
+        "dataloader": "2.0.0",
+        "is-promise": "4.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/graphql-file-loader": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.2.6.tgz",
+      "integrity": "sha512-L+RdYl5C6+X0zdOTUotY0K5zwqvSGpqI/qcZpVvCDenoAcVTyaNLmnd/ViErwedhCaGqAAV0wI1nPtyKFPlMUg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/import": "^6.2.5",
+        "@graphql-tools/utils": "^7.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/import": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.2.5.tgz",
+      "integrity": "sha512-ZGXT5tDod7m+LO38fc+o0JzR1LstL0RF35HKEWoUdxRIVaaeYH9VMuan9Gn+9M9RDME3RnzEa9aGzf9ATj8bTA==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "5.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/json-file-loader": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-6.2.6.tgz",
+      "integrity": "sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^7.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/load": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-6.2.5.tgz",
+      "integrity": "sha512-TpDgp+id0hhD1iMhdFSgWgWumdI/IpFWwouJeaEhEEAEBkdvH4W9gbBiJBSbPQwMPRNWx8/AZtry0cYKLW4lHg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/merge": "^6.2.5",
+        "@graphql-tools/utils": "^7.0.0",
+        "globby": "11.0.1",
+        "import-from": "3.0.0",
+        "is-glob": "4.0.1",
+        "p-limit": "3.0.2",
+        "tslib": "~2.0.1",
+        "unixify": "1.0.0",
+        "valid-url": "1.0.9"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "import-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+          "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.6.tgz",
+      "integrity": "sha512-G6x0QlIzFHoJ3dyF9a4gxmBtaEYJ+EoAAGqXHsE/drRr58K1jscQdfKZdF1wZWZgxkgakHqgt1+oFMeQg/O6ug==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/schema": "^7.0.0",
+        "@graphql-tools/utils": "^7.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.2.tgz",
+      "integrity": "sha512-GabNT51ErVHE2riDH4EQdRusUsI+nMElT8LdFHyuP53v8gwtleAj+LePQ9jif4NYUe/JQVqO8V28vPcHrA7gfQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^7.1.2",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/url-loader": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.6.0.tgz",
+      "integrity": "sha512-iZp6bCKU0AmGKRrsDOYqehg5mVImQS1/JMBvh73VPRp9ry2I1oxsE124Q54t3lHhD2b1wrQ9AJlXxgNsuxmJtQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "^7.0.1",
+        "@graphql-tools/utils": "^7.1.4",
+        "@graphql-tools/wrap": "^7.0.4",
+        "@types/websocket": "1.0.1",
+        "cross-fetch": "3.0.6",
+        "eventsource": "1.0.7",
+        "extract-files": "9.0.0",
+        "graphql-upload": "^11.0.0",
+        "graphql-ws": "2.0.1",
+        "is-promise": "4.0.0",
+        "isomorphic-form-data": "2.0.0",
+        "isomorphic-ws": "4.0.1",
+        "sse-z": "0.3.0",
+        "sync-fetch": "0.3.0",
+        "tslib": "~2.0.1",
+        "valid-url": "1.0.9",
+        "ws": "7.4.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.2.4.tgz",
+      "integrity": "sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==",
+      "dev": true,
+      "requires": {
+        "@ardatan/aggregate-error": "0.0.6",
+        "camel-case": "4.1.1",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/wrap": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.4.tgz",
+      "integrity": "sha512-txBs0W4k3WR86aEzBYXtKdGeeUXCNdRNxjQA/95T6ywNYoM8pw2mvpoXrWOvzbeaH3zwhbHY7kwii4atrC9irg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "^7.0.7",
+        "@graphql-tools/schema": "^7.1.2",
+        "@graphql-tools/utils": "^7.1.4",
+        "is-promise": "4.0.0",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz",
+          "integrity": "sha512-4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.2",
+            "tslib": "~2.0.1"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+          "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+          "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+          "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+          "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "@graphql-typed-document-node/core": {
@@ -1265,6 +2131,12 @@
       "requires": {
         "@hapi/hoek": "^8.3.0"
       }
+    },
+    "@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -2284,6 +3156,15 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
+    "@types/websocket": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.1.tgz",
+      "integrity": "sha512-f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "13.0.11",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
@@ -2745,6 +3626,12 @@
           }
         }
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -3801,6 +4688,15 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
+      "requires": {
+        "dicer": "0.3.0"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -4470,6 +5366,15 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cosmiconfig-toml-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
+      "integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
+      "dev": true,
+      "requires": {
+        "@iarna/toml": "^2.2.5"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -4509,6 +5414,21 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -4876,6 +5796,12 @@
         }
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+      "dev": true
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -5079,6 +6005,21 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "0.1.2"
+      }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -5729,6 +6670,18 @@
         "lodash": "^4.17.15"
       }
     },
+    "eslint-plugin-graphql": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-graphql/-/eslint-plugin-graphql-4.0.0.tgz",
+      "integrity": "sha512-d5tQm24YkVvCEk29ZR5ScsgXqAGCjKlMS8lx3mS7FS/EKsWbkvXQImpvic03EpMIvNTBW5e+2xnHzXB/VHNZJw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.0",
+        "graphql-config": "^3.0.2",
+        "lodash.flatten": "^4.4.0",
+        "lodash.without": "^4.4.0"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
@@ -6303,6 +7256,12 @@
         }
       }
     },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "dev": true
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -6666,6 +7625,12 @@
         }
       }
     },
+    "fs-capacitor": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
+      "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -6959,10 +7924,131 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
       "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
     },
+    "graphql-config": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.2.0.tgz",
+      "integrity": "sha512-ygEKDeQNZKpm4137560n2oY3bGM0D5zyRsQVaJntKkufWdgPg6sb9/4J1zJW2y/yC1ortAbhNho09qmeJeLa9g==",
+      "dev": true,
+      "requires": {
+        "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
+        "@graphql-tools/graphql-file-loader": "^6.0.0",
+        "@graphql-tools/json-file-loader": "^6.0.0",
+        "@graphql-tools/load": "^6.0.0",
+        "@graphql-tools/merge": "^6.0.0",
+        "@graphql-tools/url-loader": "^6.0.0",
+        "@graphql-tools/utils": "^6.0.0",
+        "cosmiconfig": "6.0.0",
+        "cosmiconfig-toml-loader": "1.0.0",
+        "minimatch": "3.0.4",
+        "string-env-interpolation": "1.0.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+          "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
     "graphql-tag": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
       "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+    },
+    "graphql-upload": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
+      "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
+      "dev": true,
+      "requires": {
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^6.1.0",
+        "http-errors": "^1.7.3",
+        "isobject": "^4.0.0",
+        "object-path": "^0.11.4"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+          "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+          "dev": true
+        }
+      }
+    },
+    "graphql-ws": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-2.0.1.tgz",
+      "integrity": "sha512-K8eaR00TZHFMVw2viZfjDxLWdF1hUIR8xY9Zow6tLI2CLT3E4homJ4XZNRrxEoQjAXEQoUHPcmGkDDynWivNrQ==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -7796,6 +8882,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -7880,6 +8972,21 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-form-data": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
+      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
+      "dev": true,
+      "requires": {
+        "form-data": "^2.3.2"
+      }
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -8807,6 +9914,18 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8843,6 +9962,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
       "integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
+      "dev": true
     },
     "loglevel": {
       "version": "1.7.0",
@@ -8910,6 +10035,12 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -9513,6 +10644,12 @@
       "resolved": "https://registry.npmjs.org/no-scroll/-/no-scroll-2.1.1.tgz",
       "integrity": "sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ=="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -9920,6 +11057,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object-path": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -13426,6 +14569,12 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sse-z": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sse-z/-/sse-z-0.3.0.tgz",
+      "integrity": "sha512-jfcXynl9oAOS9YJ7iqS2JMUEHOlvrRAD+54CENiWnc4xsuVLQVSgmwf7cwOTcBd/uq3XkQKBGojgvEtVXcJ/8w==",
+      "dev": true
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -13608,10 +14757,22 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-env-interpolation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",
@@ -13943,6 +15104,28 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "sync-fetch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.0.tgz",
+      "integrity": "sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.7.0",
+        "node-fetch": "^2.6.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
     },
     "tabbable": {
       "version": "3.1.2",
@@ -14299,6 +15482,20 @@
         "tslib": "^1.9.3"
       }
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "ts-pnp": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
@@ -14438,6 +15635,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^2.1.1"
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -14757,6 +15963,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -15762,6 +16974,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "zen-observable": {
       "version": "0.8.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "build": "react-scripts build",
     "postbuild": "echo 'pushstate: enabled' > build/Staticfile",
     "lint": "npm-run-all -p lint:eslint lint:prettier",
-    "lint:eslint": "eslint --quiet --ext .js --ext .jsx ./src",
+    "lint:eslint": "eslint --quiet --ext .js --ext .jsx --ext .tsx ./src",
     "lint:prettier": "prettier -c ./src",
     "test": "TZ='UTC' react-scripts test --passWithNoTests",
     "eject": "react-scripts eject",
@@ -64,7 +64,13 @@
     "maintenance-azure-beta": "mkdir -p /tmp/maintenance && /bin/cp -f public/maintenance.html /tmp/maintenance/index.html && az storage blob upload-batch -s /tmp/maintenance/ -d '$web' --account-name usdssimplereportbeta --destination-path '/app/'"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "plugins": [
+      "graphql"
+    ],
+    "rules": {
+      "graphql/template-strings": ["error", {"env": "apollo"}]
+    }
   },
   "browserslist": {
     "production": [
@@ -87,6 +93,7 @@
     "@types/react-redux": "^7.1.11",
     "@types/uuid": "^8.3.0",
     "mockdate": "^3.0.2",
+    "eslint-plugin-graphql": "^4.0.0",
     "node-sass": "^4.14.1",
     "npm-run-all": "^4.1.5",
     "prettier": "2.2.0",


### PR DESCRIPTION
Installed the Apollo graphql plugin for eslint, and told eslint to use it (and how to find the schema).

Also told eslint to check .tsx files, but not .ts files because we need to upgrade before it can do that (see typescript-eslint/typescript-eslint#2446).

I just enabled the basic query validation rule, but there are [several other options available](https://github.com/apollographql/eslint-plugin-graphql#selecting-validation-rules) (along with some configuration tweaks that could be applied to this one).