### PR TITLE
Updated patient resolver to pull only past results.

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Patient.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/Patient.java
@@ -1,8 +1,6 @@
 package gov.cdc.usds.simplereport.api.model;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import gov.cdc.usds.simplereport.db.model.Person;
 
@@ -13,6 +11,10 @@ public class Patient {
 	public Patient(Person person) {
 		super();
 		this.person = person;
+	}
+
+	public Person getWrapped() {
+		return person;
 	}
 
 	public String getInternalId() {
@@ -97,11 +99,5 @@ public class Patient {
 
 	public Boolean getEmployedInHealthcare() {
 		return person.getEmployedInHealthcare();
-	}
-
-	public List<ApiTestOrder> getTestResults() {
-		return person.getTestResults().stream()
-		.map(o -> new ApiTestOrder(o))
-		.collect(Collectors.toList());
 	}
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/PatientResult.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/PatientResult.java
@@ -1,0 +1,33 @@
+package gov.cdc.usds.simplereport.api.model;
+
+import java.util.Date;
+import java.util.UUID;
+
+import gov.cdc.usds.simplereport.db.model.TestEvent;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+
+public class PatientResult {
+
+    private TestEvent event;
+
+    public PatientResult(TestEvent event) {
+        super();
+        this.event = event;
+    }
+
+    public Date getDateTested() {
+        return event.getCreatedAt();
+    }
+
+    public TestResult getResult() {
+        return event.getResult();
+    }
+
+    public UUID getInternalId() {
+        return event.getInternalId();
+    }
+
+    public UUID getId() {
+        return getInternalId();
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/patient/PatientDataResolver.java
@@ -1,0 +1,25 @@
+package gov.cdc.usds.simplereport.api.patient;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import gov.cdc.usds.simplereport.api.model.Patient;
+import gov.cdc.usds.simplereport.api.model.PatientResult;
+import gov.cdc.usds.simplereport.service.TestOrderService;
+import graphql.kickstart.tools.GraphQLResolver;
+
+@Component
+public class PatientDataResolver implements GraphQLResolver<Patient> {
+
+    @Autowired
+    public TestOrderService _svc;
+
+    public List<PatientResult> getTestResults(Patient p) {
+        return _svc.getTestResults(p.getWrapped()).stream()
+                .map(PatientResult::new)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Person.java
@@ -16,9 +16,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import java.time.LocalDate;
-import java.util.List;
 
 /**
  * The person record (generally, a patient getting a test).
@@ -65,10 +63,6 @@ public class Person extends OrganizationScopedEternalEntity {
 	private PersonRole role;
 	@Column(nullable = false)
 	private boolean residentCongregateSetting;
-	@OneToMany()
-	@JoinColumn(name = "patient_id")
-	@JsonIgnore // dear Lord do not attempt to serialize this
-	private List<TestOrder> testOrders;
 
 	protected Person() { /* for hibernate */ }
 
@@ -244,11 +238,6 @@ public class Person extends OrganizationScopedEternalEntity {
 			return "";
 		}
 		return address.getCounty();
-	}
-
-	@JsonIgnore
-	public List<TestOrder> getTestResults() {
-		return testOrders;
 	}
 
 	public PersonRole getRole() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -19,7 +19,6 @@ import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
-import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.PatientAnswersRepository;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
@@ -37,7 +36,6 @@ public class TestOrderService {
   private TestOrderRepository _repo;
   private PatientAnswersRepository _parepo;
   private TestEventRepository _terepo;
-  private FacilityRepository _facilityRepo;
 
   public TestOrderService(
     OrganizationService os,
@@ -45,8 +43,7 @@ public class TestOrderService {
     TestOrderRepository repo,
     PatientAnswersRepository parepo,
     TestEventRepository terepo,
-    PersonService ps,
-    FacilityRepository frepo
+          PersonService ps
   ) {
     _os = os;
     _ps = ps;
@@ -54,7 +51,6 @@ public class TestOrderService {
     _repo = repo;
     _parepo = parepo;
     _terepo = terepo;
-    _facilityRepo = frepo;
 }
 
   public List<TestOrder> getQueue(String facilityId) {
@@ -62,9 +58,15 @@ public class TestOrderService {
     return _repo.fetchQueue(fac.getOrganization(), fac);
   }
 
+  @Transactional(readOnly = true)
   public List<TestEvent> getTestResults(String facilityId) {
     Facility fac = _os.getFacilityInCurrentOrg(UUID.fromString(facilityId));
     return _terepo.findAllByOrganizationAndFacility(fac.getOrganization(), fac);
+  }
+
+  @Transactional(readOnly = true)
+  public List<TestEvent> getTestResults(Person patient) {
+      return _terepo.findAllByPatient(patient);
   }
 
   public void addTestResult(String deviceID, TestResult result, String patientId) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -23,7 +23,10 @@ graphql:
   datetime:
     scalars:
       Date:
+        scalar-name: DateTime
         format: yyyy-MM-dd'T'HH:MM:ss'Z'
+      LocalDate:
+        format: yyyy-MM-dd
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -1,5 +1,13 @@
 # java.util.Date implementation
-scalar Date
+scalar DateTime
+# java.time.LocalDate
+scalar LocalDate
+
+enum ResultValue {
+  POSITIVE
+  NEGATIVE
+  UNDETERMINED
+}
 
 type DeviceType {
   internalId: ID
@@ -30,7 +38,7 @@ type Patient {
   role: String
   residentCongregateSetting: Boolean
   employedInHealthcare: Boolean
-  testResults: [TestOrder]
+  testResults: [PatientTestResult!]!
 }
 type Facility {
   id: ID
@@ -66,6 +74,13 @@ type Organization {
   name: String
   testingFacility: [Facility]
 }
+# When starting from the patient, take a more limited view
+type PatientTestResult {
+  internalId: ID
+  id: ID
+  dateTested: DateTime
+  result: ResultValue
+}
 # TestResult and TestOrder should have the same properties
 type TestOrder {
   internalId: ID
@@ -97,7 +112,7 @@ type TestResult {
   priorTestResult: String
   deviceType: DeviceType
   result: String
-  dateTested: Date
+  dateTested: DateTime
 }
 
 type User {


### PR DESCRIPTION
## Related Issue or Background Info

This addresses the problem identified in #275, where incomplete test orders were being shown as "past tests" on the individual patient page. As a side-effect, it addresses the previously-noted problem in #287 (incorrect dates).

## Changes Proposed

* removed the bidirectional relationship between Person and TestOrder
* added a separate resolver for fetching a limited view of TestEvent when the Patient model is queried
* made that resolver return better data, albeit less of it

## Additional Information

This is a call-compatible modifiation to the graphql schema, as long as nobody has added other queries on a branch.

Resolves #287.