### PR TITLE
Don't show '0' when no patient test results

### DIFF
--- a/frontend/src/app/patients/PatientForm.jsx
+++ b/frontend/src/app/patients/PatientForm.jsx
@@ -497,7 +497,7 @@ const PatientForm = (props) => {
         </div>
       </Fieldset>
       <Fieldset legend="Test History">
-        {patient.testResults && patient.testResults.length && (
+        {patient.testResults && patient.testResults.length !== 0 && (
           <table className="usa-table usa-table--borderless">
             <thead>
               <tr>


### PR DESCRIPTION
## Related Issue or Background Info

Fixes #275 now that #291 has landed for the backend

## Changes Proposed

- On the Edit Patient page, don't show a `0` below the Test History heading when there are no tests.




