### PR TITLE
Save QueueItem state without the need to submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ https://simplereport.cdc.gov/
   - [Setup](#backend-Setup)
   - [Restart & Clean](#restart-&-clean)
   - [API Testing](#api-testing)
+  - [Tests](#tests)
 - [Frontend](#frontend)
   - [Setup](#frontend-Setup)
 - [Deploy](#Deploy)
@@ -77,6 +78,16 @@ Restarting the SQL way:
 ## API Testing
 
 Go to `localhost:8080` to see interact with the graphql api. You would need to point the api endpoint to the backend at: `http://localhost:8080/graphql` This gives you a preview to query/mutate the local database.
+
+## Tests
+
+All the test can be run with `gradle test`
+
+Running a single test with a full stacktrace can be accomplished by supping the path to `gradle test`. Example
+
+```bash
+gradle test --tests gov.cdc.usds.simplereport.api.QueueManagementTest.updateItemInQueue --stacktrace
+```
 
 ## Frontend
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -44,7 +44,7 @@ public class QueueMutationResolver implements GraphQLMutationResolver  {
         return new ApiTestOrder(_tos.editQueueItem(
             id,
             deviceId,
-            TestResult.valueOf(result)
+            result
         ));
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -12,6 +12,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
+import gov.cdc.usds.simplereport.api.model.ApiTestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
 import gov.cdc.usds.simplereport.service.PersonService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
@@ -37,6 +38,14 @@ public class QueueMutationResolver implements GraphQLMutationResolver  {
         TestResult.valueOf(result),
         patientID
       );
+    }
+
+    public ApiTestOrder editQueueItem(String id, String deviceId, String result) {
+        return new ApiTestOrder(_tos.editQueueItem(
+            id,
+            deviceId,
+            TestResult.valueOf(result)
+        ));
     }
 
     public void addPatientToQueue(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -62,9 +62,12 @@ public class TestOrder extends BaseTestInfo {
 
 	public void setResult(TestResult finalResult) {
 		super.setTestResult(finalResult);
-		dateTested = LocalDate.now();
-		orderStatus = OrderStatus.COMPLETED;
 	}
+
+    public void markComplete() {
+        dateTested = LocalDate.now();
+        orderStatus = OrderStatus.COMPLETED;
+    }
 
 	public void cancelOrder() {
 		orderStatus = OrderStatus.CANCELED;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepository.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.db.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Modifying;
@@ -33,6 +34,9 @@ public interface TestOrderRepository extends AuditedEntityRepository<TestOrder> 
 	@Query(BASE_ORG_QUERY + IS_PENDING + " and q.patient = :patient")
 	@EntityGraph(attributePaths = "patient")
 	public Optional<TestOrder> fetchQueueItem(Organization org, Person patient);
+
+	@Query(BASE_ORG_QUERY + IS_PENDING + " and q.id = :id")
+	public Optional<TestOrder> fetchQueueItemById(Organization org, UUID id);
 
 	@Query(BASE_ORG_QUERY + IS_COMPLETED)
 	@EntityGraph(attributePaths = "patient")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -75,7 +75,7 @@ public class TestOrderService {
         return _repo.fetchQueueItemById(org, UUID.fromString(id)).orElseThrow(TestOrderService::noSuchOrderFound);
     }
 
-    public TestOrder editQueueItem(String id, String deviceId, TestResult result) {
+    public TestOrder editQueueItem(String id, String deviceId, String result) {
         Organization org = _os.getCurrentOrganization();
         TestOrder order = this.getTestOrder(id);
 
@@ -85,7 +85,7 @@ public class TestOrderService {
         }
 
         if (result != null) {
-            order.setResult(result);
+            order.setResult(TestResult.valueOf(result));
         }
 
         return _repo.save(order);

--- a/backend/src/main/resources/schema.graphqls
+++ b/backend/src/main/resources/schema.graphqls
@@ -235,6 +235,7 @@ type Mutation {
     employedInHealthcare: Boolean!
   ): String
   addTestResult(deviceId: String!, result: String!, patientId: String!): String
+  editQueueItem(id: String!, deviceId: String, result: String): TestOrder
   addPatientToQueue(
     facilityId: String!
     patientId: String!

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/TestOrderRepositoryTest.java
@@ -50,6 +50,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		queue = _repo.fetchQueueForOrganization(gtown);
 		assertEquals(1, queue.size());
 		order.setResult(TestResult.NEGATIVE);
+		order.markComplete();
 		_repo.save(order);
 		assertEquals(0, _repo.fetchQueueForOrganization(gtown).size());
 		assertEquals(1, _repo.fetchPastResultsForOrganization(gtown).size());
@@ -115,6 +116,7 @@ public class TestOrderRepositoryTest extends BaseRepositoryTest {
 		TestEvent didit = _events.save(new TestEvent(TestResult.NEGATIVE, site.getDefaultDeviceType(), patient0, site));
 		order1.setTestEvent(didit);
 		order1.setResult(didit.getResult());
+		order1.markComplete();
 		_repo.save(order1);
 		flush();
 		TestOrder order2 = new TestOrder(patient0, site);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -1,0 +1,85 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.Person;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.auxiliary.TestResult;
+
+public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
+
+    @Autowired
+    private DeviceTypeService _deviceTypeService;
+    @Autowired
+    private OrganizationService _organizationService;
+    @Autowired
+    private PersonService _personService;
+
+    @Test
+    public void addPatientToQueue() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.",
+            LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
+            "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
+        
+        _service.addPatientToQueue(facility.getInternalId(), p, "",
+            Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
+            TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
+        assertEquals(1, queue.size());
+    }
+
+    @Test
+    public void addTestResult() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.",
+            LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
+            "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
+        _service.addPatientToQueue(facility.getInternalId(), p, "",
+            Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
+            TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+        DeviceType devA = _deviceTypeService.createDeviceType("A", "B", "C", "DUMMY");
+
+        _service.addTestResult(devA.getInternalId().toString(), TestResult.POSITIVE,
+            p.getInternalId().toString());
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void editTestResult() {
+        Organization org = _organizationService.getCurrentOrganization();
+        Facility facility = _organizationService.getFacilities(org).get(0);
+        Person p = _personService.addPatient(null, "FOO", "Fred", null, "", "Sr.",
+            LocalDate.of(1865, 12, 25), "123 Main", "Apartment 3", "Syracuse", "NY", "11801",
+            "8883334444", "STAFF", null, "Nassau", null, null, null, false, false);
+        TestOrder o = _service.addPatientToQueue(facility.getInternalId(), p, "",
+            Collections.<String, Boolean>emptyMap(), false, LocalDate.of(1865, 12, 25), "",
+            TestResult.POSITIVE, LocalDate.of(1865, 12, 25), false);
+        DeviceType devA = _deviceTypeService.createDeviceType("A", "B", "C", "DUMMY");
+
+        _service.editQueueItem(o.getInternalId().toString(), devA.getInternalId().toString(),
+            TestResult.POSITIVE);
+
+        List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
+        assertEquals(1, queue.size());
+        assertEquals(TestResult.POSITIVE, queue.get(0).getTestResult());
+        assertEquals(devA.getInternalId(), queue.get(0).getDeviceType().getInternalId());
+    }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -75,7 +75,7 @@ public class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         DeviceType devA = _deviceTypeService.createDeviceType("A", "B", "C", "DUMMY");
 
         _service.editQueueItem(o.getInternalId().toString(), devA.getInternalId().toString(),
-            TestResult.POSITIVE);
+            TestResult.POSITIVE.toString());
 
         List<TestOrder> queue = _service.getQueue(facility.getInternalId().toString());
         assertEquals(1, queue.size());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -10,15 +10,20 @@ import org.springframework.stereotype.Component;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.model.PatientAnswers;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Provider;
+import gov.cdc.usds.simplereport.db.model.TestOrder;
+import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonRole;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.repository.DeviceTypeRepository;
 import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
+import gov.cdc.usds.simplereport.db.repository.PatientAnswersRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
+import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 
 @Component
 public class TestDataFactory {
@@ -34,6 +39,10 @@ public class TestDataFactory {
 	private ProviderRepository _providerRepo;
 	@Autowired
 	private DeviceTypeRepository _deviceRepo;
+    @Autowired
+    private TestOrderRepository _testOrderRepo;
+    @Autowired
+    private PatientAnswersRepository _patientAnswerRepo;
 
 	public Organization createValidOrg() {
 		return _orgRepo.save(new Organization("The Mall", "MALLRAT"));
@@ -64,6 +73,15 @@ public class TestDataFactory {
 		);
 		return _personRepo.save(p);
 	}
+
+    public TestOrder createTestOrder(Person p, Facility f) {
+        AskOnEntrySurvey survey = new AskOnEntrySurvey(null,Collections.emptyMap(),null,null,null,null,null,null);
+        PatientAnswers answers = new PatientAnswers(survey);
+        _patientAnswerRepo.save(answers);
+        TestOrder o = new TestOrder(p, f);
+        o.setAskOnEntrySurvey(answers);
+        return _testOrderRepo.save(o);
+    }
 
 	public DeviceType getGenericDevice() {
 		return _deviceRepo.findAll().stream().filter(d->d.getName().equals(DEFAULT_DEVICE_TYPE)).findFirst()

--- a/backend/src/test/resources/edit-queue-item
+++ b/backend/src/test/resources/edit-queue-item
@@ -1,0 +1,13 @@
+mutation EditQueueItem($id: String!, $deviceId: String, $result: String) {
+    editQueueItem(
+      id: $id,
+      deviceId: $deviceId,
+      result: $result
+    ) {
+      internalId,
+      result,
+      deviceType {
+        internalId
+      }
+    }
+  }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,12 @@
       "graphql"
     ],
     "rules": {
-      "graphql/template-strings": ["error", {"env": "apollo"}]
+      "graphql/template-strings": [
+        "error",
+        {
+          "env": "apollo"
+        }
+      ]
     }
   },
   "browserslist": {
@@ -90,10 +95,11 @@
     "@types/node": "^14.14.10",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@types/react-modal": "^3.10.6",
     "@types/react-redux": "^7.1.11",
     "@types/uuid": "^8.3.0",
-    "mockdate": "^3.0.2",
     "eslint-plugin-graphql": "^4.0.0",
+    "mockdate": "^3.0.2",
     "node-sass": "^4.14.1",
     "npm-run-all": "^4.1.5",
     "prettier": "2.2.0",

--- a/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
+++ b/frontend/src/app/testQueue/AoEForm/AoEModalForm.jsx
@@ -228,7 +228,7 @@ const AoEModalForm = ({
   patient,
   facilityId,
   loadState = {},
-  saveCallback = () => null,
+  saveCallback,
 }) => {
   // this seems like it will do a bunch of wasted work on re-renders and non-renders,
   // but it's all small-ball stuff for now

--- a/frontend/src/app/testQueue/QueueItem.tsx
+++ b/frontend/src/app/testQueue/QueueItem.tsx
@@ -13,13 +13,13 @@ import Alert from "../commonComponents/Alert";
 import { Button } from "@cmsgov/design-system";
 import Anchor from "../commonComponents/Anchor";
 import AoeModalForm from "./AoEForm/AoEModalForm";
-import Dropdown from "../commonComponents//Dropdown";
-import LabeledText from "../commonComponents//LabeledText";
+import Dropdown from "../commonComponents/Dropdown";
+import LabeledText from "../commonComponents/LabeledText";
 import TestResultInputForm from "../testResults/TestResultInputForm";
-import { ALERT_CONTENT } from "../testQueue/constants";
+import { ALERT_CONTENT } from "./constants";
 import { displayFullName } from "../utils";
 import { patientPropType, devicePropType } from "../propTypes";
-import { QUEUE_NOTIFICATION_TYPES } from "../testQueue/constants";
+import { QUEUE_NOTIFICATION_TYPES } from "./constants";
 import { showNotification } from "../utils";
 import AskOnEntryTag, { areAnswersComplete } from "./AskOnEntryTag";
 import { removeTimer, TestTimerWidget } from "./TestTimer";
@@ -63,7 +63,17 @@ const UPDATE_AOE = gql`
   }
 `;
 
-const AreYouSure = ({ patientName, cancelHandler, continueHandler }) => (
+interface AreYouSureProps {
+  patientName: string;
+  cancelHandler: () => void;
+  continueHandler: () => void;
+}
+
+const AreYouSure: React.FC<AreYouSureProps> = ({
+  patientName,
+  cancelHandler,
+  continueHandler,
+}) => (
   <Modal
     isOpen={true}
     style={{
@@ -92,7 +102,32 @@ const AreYouSure = ({ patientName, cancelHandler, continueHandler }) => (
 );
 Modal.setAppElement("#root");
 
-const QueueItem = ({
+interface QueueItemProps {
+  internalId: string;
+  patient: {
+    internalId: string;
+    firstName: string;
+    middleName: string;
+    lastName: string;
+    lookupId: string;
+    telephone: string;
+    birthDate: string;
+  };
+  devices: {
+    name: string;
+    internalId: string;
+  }[];
+  askOnEntry: string;
+  selectedDeviceId: string;
+  selectedTestResult: string;
+  defaultDevice: {
+    internalId: string;
+  };
+  refetchQueue: () => void;
+  facilityId: string;
+}
+
+const QueueItem: any = ({
   internalId,
   patient,
   devices,
@@ -102,19 +137,22 @@ const QueueItem = ({
   defaultDevice,
   refetchQueue,
   facilityId,
-}) => {
+}: QueueItemProps) => {
   const appInsights = useAppInsightsContext();
   const trackRemovePatientFromQueue = useTrackEvent(
     appInsights,
-    "Remove Patient From Queue"
+    "Remove Patient From Queue",
+    {}
   );
   const trackSubmitTestResult = useTrackEvent(
     appInsights,
-    "Submit Test Result"
+    "Submit Test Result",
+    {}
   );
   const trackUpdateAoEResponse = useTrackEvent(
     appInsights,
-    "Update AoE Response"
+    "Update AoE Response",
+    {}
   );
 
   const [mutationError, updateMutationError] = useState(null);
@@ -152,10 +190,10 @@ const QueueItem = ({
     removeTimer(internalId);
   };
 
-  const onTestResultSubmit = (e) => {
+  const onTestResultSubmit = (e?: any) => {
     if (e) e.preventDefault();
     if (forceSubmit || areAnswersComplete(aoeAnswers)) {
-      trackSubmitTestResult();
+      trackSubmitTestResult({});
       submitTestResult({
         variables: {
           patientId: patient.internalId,
@@ -173,12 +211,12 @@ const QueueItem = ({
     }
   };
 
-  const onDeviceChange = (e) => {
-    updateDeviceId(e.target.value);
+  const onDeviceChange = (e: React.FormEvent<HTMLSelectElement>) => {
+    updateDeviceId((e.target as HTMLSelectElement).value);
   };
 
-  const removeFromQueue = (patientId) => {
-    trackRemovePatientFromQueue();
+  const removeFromQueue = (patientId: string) => {
+    trackRemovePatientFromQueue({});
     removePatientFromQueue({
       variables: {
         patientId,
@@ -191,15 +229,6 @@ const QueueItem = ({
     );
   };
 
-  const onTestResultChange = (newTestResultValue) => {
-    updateTestResultValue(newTestResultValue);
-  };
-
-  const onClearClick = (e) => {
-    e.preventDefault();
-    onTestResultChange(null);
-  };
-
   const openAoeModal = () => {
     updateIsAoeModalOpen(true);
   };
@@ -208,9 +237,9 @@ const QueueItem = ({
     updateIsAoeModalOpen(false);
   };
 
-  const saveAoeCallback = (answers) => {
+  const saveAoeCallback = (answers: any) => {
     setAoeAnswers(answers);
-    trackUpdateAoEResponse();
+    trackUpdateAoEResponse({});
     updateAoe({
       variables: {
         patientId: patient.internalId,
@@ -326,8 +355,7 @@ const QueueItem = ({
             <TestResultInputForm
               testResultValue={testResultValue}
               onSubmit={onTestResultSubmit}
-              onChange={onTestResultChange}
-              onClearClick={onClearClick}
+              onChange={updateTestResultValue}
             />
           </div>
         </div>

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -44,6 +44,7 @@ const queueQuery = gql`
         lastName
         gender
       }
+      result
     }
     organization {
       testingFacility {
@@ -75,13 +76,13 @@ interface QueueItem {
   priorTestDate: string;
   priorTestType: string;
   priorTestResult: string;
-  device: {
+  deviceType: {
     internalId: string;
   };
   patient: {
     internalId: string;
   };
-  testResult: string;
+  result: string;
   symptomOnset: string;
 }
 
@@ -121,9 +122,9 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
             priorTestDate,
             priorTestType,
             priorTestResult,
-            device,
+            deviceType,
             patient,
-            testResult,
+            result,
             symptomOnset,
           }) => (
             <QueueItem
@@ -141,8 +142,8 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
                 priorTestType,
                 priorTestResult,
               }}
-              selectedDeviceId={device ? device.internalId : null}
-              selectedTestResult={testResult}
+              selectedDeviceId={deviceType ? deviceType.internalId : null}
+              selectedTestResult={result}
               devices={facility.deviceTypes}
               defaultDevice={facility.defaultDeviceType}
               refetchQueue={refetchQueue}

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -106,7 +106,7 @@ export const useTestTimer = (id: string) => {
   };
 };
 
-export const TestTimerWidget = (props: { id: string }): React.ReactNode => {
+export const TestTimerWidget = (props: { id: string }) => {
   const { running, countdown, elapsed, reset, start } = useTestTimer(props.id);
   const mmss = (t: number) => {
     const mins = Math.floor(Math.abs(t) / 60);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2018,6 +2018,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-modal@^3.10.6":
+  version "3.10.6"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.10.6.tgz#76717220f32bc72769190692147814a540053c7e"
+  integrity sha512-XpshhwVYir1TRZ2HS5EfmNotJjB8UEC2IkT3omNtiQzROOXSzVLz5xsjwEpACP8U+PctkpfZepX+WT5oDf0a9g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.11":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.12.tgz#148f2c768687346b556e29a322ca44cfa28cc3ac"


### PR DESCRIPTION
## Related Issue or Background Info

https://github.com/CDCgov/prime-data-input-client/issues/75

## Changes Proposed

- [x] adds `editQueueItem` to the API
- [x] sends API request on device change and result select

## Additional Information

## Screenshots / Demos
